### PR TITLE
Secure make-seller endpoint

### DIFF
--- a/server/auth.ts
+++ b/server/auth.ts
@@ -150,10 +150,8 @@ export function setupAuth(app: Express) {
   });
   
   // Temporary endpoint to make the current user a seller for testing
-  app.post("/api/make-seller", async (req, res) => {
-    if (!req.isAuthenticated()) {
-      return res.status(401).json({ error: "Unauthorized" });
-    }
+  // Protected by admin check to prevent privilege escalation
+  app.post("/api/make-seller", isAuthenticated, isAdmin, async (req, res) => {
     
     try {
       const user = req.user;


### PR DESCRIPTION
## Summary
- add admin middleware to `/api/make-seller` so normal users can't upgrade roles

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node' and 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_684742fc6be08330a3363a7abd5a2a99