### PR TITLE
Fix error middleware

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -44,7 +44,8 @@ app.use((req, res, next) => {
     const message = err.message || "Internal Server Error";
 
     res.status(status).json({ message });
-    throw err;
+    console.error(err);
+    return;
   });
 
   // importantly only setup vite in development and after


### PR DESCRIPTION
## Summary
- log errors instead of throwing from middleware

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_684742f30864833081220ff8866c933f