### PR TITLE
Allow configuring server port via env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Sycloseouts
+
+This project serves the API and client from a single Express server.
+
+## Configuration
+
+The server reads the port from the `PORT` environment variable. If `PORT` is not set or is invalid, the server falls back to port `5000`.
+
+```bash
+PORT=3000 npm run dev
+```
+
+If the specified port is already in use, the server logs an error message.

--- a/server/index.ts
+++ b/server/index.ts
@@ -57,15 +57,26 @@ app.use((req, res, next) => {
     serveStatic(app);
   }
 
-  // ALWAYS serve the app on port 5000
-  // this serves both the API and the client.
-  // It is the only port that is not firewalled.
-  const port = 5000;
-  server.listen({
-    port,
-    host: "0.0.0.0",
-    reusePort: true,
-  }, () => {
-    log(`serving on port ${port}`);
+  // Determine the port from the environment with a fallback to 5000.
+  const envPort = parseInt(process.env.PORT ?? "", 10);
+  const port = Number.isFinite(envPort) ? envPort : 5000;
+
+  server.listen(
+    {
+      port,
+      host: "0.0.0.0",
+      reusePort: true,
+    },
+    () => {
+      log(`serving on port ${port}`);
+    },
+  );
+
+  server.on("error", (err: NodeJS.ErrnoException) => {
+    if (err.code === "EADDRINUSE") {
+      console.error(`Port ${port} is already in use.`);
+    } else {
+      console.error("Failed to start server:", err);
+    }
   });
 })();


### PR DESCRIPTION
## Summary
- make server port configurable by `PORT` env variable with fallback to 5000
- log errors when the server can't bind, specifically when the port is already in use
- document the new configuration in `README.md`

## Testing
- `npm run check` *(fails: npm missing)*

------
https://chatgpt.com/codex/tasks/task_e_684757f8a3488330a0037d8d245bcf4f