### PR TITLE
Fix product form image uploads

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -3,7 +3,8 @@ import { registerRoutes } from "./routes";
 import { setupVite, serveStatic, log } from "./vite";
 
 const app = express();
-app.use(express.json());
+// Increase JSON body size limit to handle base64-encoded images
+app.use(express.json({ limit: "10mb" }));
 app.use(express.urlencoded({ extended: false }));
 
 app.use((req, res, next) => {


### PR DESCRIPTION
## Summary
- allow larger JSON payloads for product creation with base64 images

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*
- `bash test_product_creation_fixed.sh` *(fails: server not running)*

------
https://chatgpt.com/codex/tasks/task_e_684761e0932083309575a0124ce51ebc