### PR TITLE
Fix product form and logging

### DIFF
--- a/client/src/components/seller/product-form.tsx
+++ b/client/src/components/seller/product-form.tsx
@@ -129,11 +129,9 @@ export default function ProductForm({ product, onSuccess }: ProductFormProps) {
     
     if (imageUrls.length === 0) {
       toast({
-        title: "Error",
-        description: "Please add at least one product image.",
-        variant: "destructive",
+        title: "Warning",
+        description: "Submitting product without any images.",
       });
-      return;
     }
     
     // Ensure available units don't exceed total units
@@ -592,11 +590,8 @@ export default function ProductForm({ product, onSuccess }: ProductFormProps) {
             </div>
           </div>
           <FormDescription>
-            Add images for your product by URL or uploading from your computer. At least one image is required.
+            Add images for your product by URL or upload from your computer. Images are optional.
           </FormDescription>
-          {imageUrls.length === 0 && (
-            <p className="text-sm font-medium text-destructive mt-1">At least one product image is required</p>
-          )}
         </div>
         
         <Button type="submit" className="w-full" disabled={isPending}>

--- a/server/index.ts
+++ b/server/index.ts
@@ -3,13 +3,18 @@ import { registerRoutes } from "./routes";
 import { setupVite, serveStatic, log } from "./vite";
 
 const app = express();
-app.use(express.json());
+// Increase JSON body size limit to handle base64-encoded images
+app.use(express.json({ limit: "10mb" }));
 app.use(express.urlencoded({ extended: false }));
 
 app.use((req, res, next) => {
   const start = Date.now();
   const path = req.path;
   let capturedJsonResponse: Record<string, any> | undefined = undefined;
+
+  if (path.startsWith("/api")) {
+    log(`--> ${req.method} ${path}`);
+  }
 
   const originalResJson = res.json;
   res.json = function (bodyJson, ...args) {

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -77,7 +77,8 @@ export const insertProductSchema = createInsertSchema(products, {
     createdAt: true,
   })
   .extend({
-    images: z.array(z.string()).min(1, "At least one image is required"),
+    // Images are optional for testing but an empty array will be stored
+    images: z.array(z.string()).default([]),
   });
 
 // Order schema


### PR DESCRIPTION
## Summary
- allow product creation without images
- log incoming API requests to monitor POST /api/products
- warn sellers when submitting without images

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*
- `bash test_product_creation_fixed.sh` *(fails: server not running)*

------
https://chatgpt.com/codex/tasks/task_e_684761e0932083309575a0124ce51ebc