### PR TITLE
Improve mobile buyer views

### DIFF
--- a/client/src/components/home/hero.tsx
+++ b/client/src/components/home/hero.tsx
@@ -17,7 +17,7 @@ export default function Hero() {
           </svg>
 
           <div className="mt-10 mx-auto max-w-7xl px-4 sm:mt-12 sm:px-6 md:mt-16 lg:mt-20 lg:px-8 xl:mt-28">
-            <div className="sm:text-center lg:text-left">
+            <div className="text-center lg:text-left">
               <h1 className="text-4xl tracking-tight font-extrabold text-gray-900 sm:text-5xl md:text-6xl">
                 <span className="block xl:inline">Wholesale Liquidation</span>{" "}
                 <span className="block text-primary xl:inline">Marketplace</span>

--- a/client/src/pages/buyer/orders.tsx
+++ b/client/src/pages/buyer/orders.tsx
@@ -80,12 +80,12 @@ export default function BuyerOrdersPage() {
                 <CardDescription>View and track all your orders</CardDescription>
               </div>
               
-              <div className="flex flex-col sm:flex-row gap-3">
+              <div className="flex flex-col sm:flex-row sm:items-center gap-3">
                 <div className="relative">
                   <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 h-4 w-4" />
                   <Input
                     placeholder="Search by order #"
-                    className="pl-10 min-w-[200px]"
+                    className="pl-10 w-full sm:w-[200px]"
                     value={searchTerm}
                     onChange={(e) => setSearchTerm(e.target.value)}
                   />
@@ -95,7 +95,7 @@ export default function BuyerOrdersPage() {
                   value={filter}
                   onValueChange={(value) => setFilter(value)}
                 >
-                  <SelectTrigger className="w-[180px]">
+                  <SelectTrigger className="w-full sm:w-[180px]">
                     <SelectValue placeholder="Filter by status" />
                   </SelectTrigger>
                   <SelectContent>

--- a/client/src/pages/product-detail-page.tsx
+++ b/client/src/pages/product-detail-page.tsx
@@ -219,7 +219,7 @@ export default function ProductDetailPage() {
                   <label htmlFor="quantity" className="block text-sm font-medium text-gray-700 mb-2">
                     Quantity
                   </label>
-                  <div className="flex items-center mb-4">
+                  <div className="flex flex-col sm:flex-row items-center mb-4 space-y-2 sm:space-y-0 sm:space-x-2">
                     <Button
                       variant="outline"
                       size="icon"


### PR DESCRIPTION
## Summary
- center hero text on small screens
- stack quantity controls on mobile
- make order filters responsive

## Testing
- `npm run check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847793295f08330a33e86973b02a0b4