### PR TITLE
Persist buyer shipping info

### DIFF
--- a/client/src/pages/checkout-page.tsx
+++ b/client/src/pages/checkout-page.tsx
@@ -19,7 +19,7 @@ import { Separator } from "@/components/ui/separator";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { Loader2, CheckCircle, CreditCard, Building, ShoppingCart } from "lucide-react";
 import { InsertOrder, InsertOrderItem } from "@shared/schema";
-import { apiRequest } from "@/lib/queryClient";
+import { apiRequest, queryClient } from "@/lib/queryClient";
 import { useToast } from "@/hooks/use-toast";
 import Header from "@/components/layout/header";
 import Footer from "@/components/layout/footer";
@@ -38,12 +38,12 @@ export default function CheckoutPage() {
   const [shippingInfo, setShippingInfo] = useState({
     name: user ? `${user.firstName} ${user.lastName}` : "",
     company: user?.company || "",
-    address: "",
+    address: user?.address || "",
     city: "",
     state: "",
     zipCode: "",
     country: "United States",
-    phone: "",
+    phone: user?.phone || "",
     email: user?.email || "",
     notes: ""
   });
@@ -83,6 +83,17 @@ export default function CheckoutPage() {
       // For each item, find the seller ID
       if (items.length === 0) {
         throw new Error("Your cart is empty");
+      }
+
+      // Save phone and address for future checkouts
+      try {
+        await apiRequest("PUT", "/api/users/me", {
+          phone: shippingInfo.phone,
+          address: shippingInfo.address,
+        });
+        queryClient.invalidateQueries({ queryKey: ["/api/user"] });
+      } catch (err) {
+        console.error("Failed to save contact info", err);
       }
       
       // Group items by seller

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -18,6 +18,8 @@ declare global {
       firstName: string;
       lastName: string;
       company?: string | null;
+      phone?: string | null;
+      address?: string | null;
       role: string;
       isSeller: boolean | null;
       isApproved: boolean | null;

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -384,6 +384,26 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
+  // Allow authenticated users to update their own contact info
+  app.put("/api/users/me", isAuthenticated, async (req, res) => {
+    try {
+      const user = req.user as Express.User;
+      const updatedUser = await storage.updateUser(user.id, {
+        phone: req.body.phone,
+        address: req.body.address,
+      });
+
+      if (!updatedUser) {
+        return res.status(404).json({ message: "User not found" });
+      }
+
+      const { password, ...userWithoutPassword } = updatedUser;
+      res.json(userWithoutPassword);
+    } catch (error) {
+      handleApiError(res, error);
+    }
+  });
+
   // Create the HTTP server
   const httpServer = createServer(app);
   return httpServer;

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -12,6 +12,8 @@ export const users = pgTable("users", {
   firstName: text("first_name").notNull(),
   lastName: text("last_name").notNull(),
   company: text("company"),
+  phone: text("phone"),
+  address: text("address"),
   role: text("role").notNull().default("buyer"), // buyer, seller, admin
   isSeller: boolean("is_seller").default(false),
   isApproved: boolean("is_approved").default(false),
@@ -34,6 +36,10 @@ export const insertUserSchema = createInsertSchema(users)
     lastName: true,
     company: true,
     role: true,
+  })
+  .extend({
+    phone: z.string().optional(),
+    address: z.string().optional(),
   })
   .refine((data) => data.password.length >= 6, {
     message: "Password must be at least 6 characters long",


### PR DESCRIPTION
## Summary
- extend `users` table with phone and address
- allow authenticated users to update their own phone and address
- pre-fill checkout page shipping form using saved info and persist on checkout

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_684777f897248330b13ccc40adaaec0a