### PR TITLE
Fix Link undefined error on checkout

### DIFF
--- a/client/src/pages/checkout-page.tsx
+++ b/client/src/pages/checkout-page.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useLocation } from "wouter";
+import { useLocation, Link } from "wouter";
 import { useCart } from "@/hooks/use-cart";
 import { useAuth } from "@/hooks/use-auth";
 import { formatCurrency, getEstimatedDeliveryDate, generateTrackingNumber } from "@/lib/utils";


### PR DESCRIPTION
## Summary
- fix runtime error by importing `Link` in checkout page

## Testing
- `npm run check` *(fails: Cannot find type definition file)*

------
https://chatgpt.com/codex/tasks/task_e_684783b54f1c83309f1eb578e0ad2ae4