### PR TITLE
Add About page

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -22,6 +22,7 @@ import SellerApply from "@/pages/seller/apply";
 import AdminDashboard from "@/pages/admin/dashboard";
 import AdminUsers from "@/pages/admin/users";
 import AdminApplications from "@/pages/admin/applications";
+import AboutPage from "@/pages/about-page";
 import NotFound from "@/pages/not-found";
 
 function Router() {
@@ -33,6 +34,7 @@ function Router() {
       <Route path="/products/:id" component={ProductDetailPage} />
       <Route path="/auth" component={AuthPage} />
       <Route path="/cart" component={CartPage} />
+      <Route path="/about" component={AboutPage} />
       
       {/* Protected seller application route */}
       <ProtectedRoute path="/seller/apply" component={SellerApply} allowedRoles={["buyer", "seller", "admin"]} />

--- a/client/src/pages/about-page.tsx
+++ b/client/src/pages/about-page.tsx
@@ -1,0 +1,20 @@
+import Header from "@/components/layout/header";
+import Footer from "@/components/layout/footer";
+
+export default function AboutPage() {
+  return (
+    <>
+      <Header />
+      <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <h1 className="text-3xl font-extrabold tracking-tight text-gray-900 sm:text-4xl mb-4">About SY Closeouts</h1>
+        <p className="text-lg text-gray-600 mb-4">
+          SY Closeouts is a platform connecting buyers and sellers of wholesale inventory at competitive prices.
+        </p>
+        <p className="text-lg text-gray-600">
+          Our mission is to make sourcing liquidation and closeout merchandise simple and transparent for businesses of all sizes.
+        </p>
+      </main>
+      <Footer />
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- create AboutPage component with basic description
- register AboutPage at `/about` in router

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_68485eb695ec833099f8bbed91663e9c