### PR TITLE
Remove price range filter and add toggleable panel

### DIFF
--- a/client/src/pages/products-page.tsx
+++ b/client/src/pages/products-page.tsx
@@ -13,8 +13,6 @@ export default function ProductsPage() {
   const [filters, setFilters] = useState({
     search: "",
     category: "All Categories",
-    minPrice: 0,
-    maxPrice: 1000,
     condition: "All Conditions",
     sort: "newest"
   });
@@ -38,11 +36,6 @@ export default function ProductsPage() {
     
     // Filter by category
     if (filters.category !== "All Categories" && product.category !== filters.category) {
-      return false;
-    }
-    
-    // Filter by price range
-    if (product.price < filters.minPrice || product.price > filters.maxPrice) {
       return false;
     }
     
@@ -108,7 +101,6 @@ export default function ProductsPage() {
             "Refurbished",
             "Used"
           ]}
-          maxPriceValue={1000}
         />
         
         <div className="flex justify-between items-center mb-6">


### PR DESCRIPTION
## Summary
- rework `ProductFilter` component to remove price range slider
- add button to toggle filter options across all screen sizes
- simplify `ProductsPage` filter state and logic

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_684860178274833088c8084ed4ba719c