### PR TITLE
Fix auto-login after registration

### DIFF
--- a/server/auth.ts
+++ b/server/auth.ts
@@ -57,8 +57,8 @@ export function setupAuth(app: Express) {
     cookie: {
       maxAge: 1000 * 60 * 60 * 24 * 7, // 1 week
       secure: process.env.NODE_ENV === "production",
-      httpOnly: true
-    }
+      httpOnly: true,
+    },
   };
 
   app.set("trust proxy", 1);
@@ -104,7 +104,8 @@ export function setupAuth(app: Express) {
         return res.status(400).json({ error: "Email already exists" });
       }
 
-      const { address, city, state, zipCode, country, phone, ...userFields } = req.body;
+      const { address, city, state, zipCode, country, phone, ...userFields } =
+        req.body;
 
       // Create new user with hashed password
       const user = await storage.createUser({
@@ -128,31 +129,51 @@ export function setupAuth(app: Express) {
         });
       }
 
-      // Log user in after registration
-      req.login(user, (err) => {
-        if (err) return next(err);
-        // Return user without password
-        const { password, ...userWithoutPassword } = user;
-        res.status(201).json(userWithoutPassword);
+      // Log user in after registration and wait for the session to be saved
+      await new Promise<void>((resolve, reject) => {
+        req.login(user, (err) => {
+          if (err) return reject(err);
+          req.session.save((saveErr) => {
+            if (saveErr) return reject(saveErr);
+            resolve();
+          });
+        });
       });
-    } catch (error) {
+
+      // Return user without password
+      const { password, ...userWithoutPassword } = user;
+      res.status(201).json(userWithoutPassword);
+    } catch (error: any) {
+      if (
+        typeof error.message === "string" &&
+        error.message.includes("duplicate key")
+      ) {
+        return res
+          .status(400)
+          .json({ error: "Username or email already exists" });
+      }
       next(error);
     }
   });
 
   app.post("/api/login", (req, res, next) => {
-    passport.authenticate("local", (err: Error | null, user: User | false, info: any) => {
-      if (err) return next(err);
-      if (!user) {
-        return res.status(401).json({ error: "Invalid username or password" });
-      }
-      req.login(user, (loginErr) => {
-        if (loginErr) return next(loginErr);
-        // Return user without password
-        const { password, ...userWithoutPassword } = user;
-        res.status(200).json(userWithoutPassword);
-      });
-    })(req, res, next);
+    passport.authenticate(
+      "local",
+      (err: Error | null, user: User | false, info: any) => {
+        if (err) return next(err);
+        if (!user) {
+          return res
+            .status(401)
+            .json({ error: "Invalid username or password" });
+        }
+        req.login(user, (loginErr) => {
+          if (loginErr) return next(loginErr);
+          // Return user without password
+          const { password, ...userWithoutPassword } = user;
+          res.status(200).json(userWithoutPassword);
+        });
+      },
+    )(req, res, next);
   });
 
   app.post("/api/logout", (req, res, next) => {
@@ -168,35 +189,34 @@ export function setupAuth(app: Express) {
     const { password, ...userWithoutPassword } = req.user;
     res.json(userWithoutPassword);
   });
-  
+
   // Temporary endpoint to make the current user a seller for testing
   // Protected by admin check to prevent privilege escalation
   app.post("/api/make-seller", isAuthenticated, isAdmin, async (req, res) => {
-    
     try {
       const user = req.user;
       console.log("Updating user to seller role:", user.id);
-      
+
       // Update the user in the database
       const updatedUser = await storage.updateUser(user.id, {
         role: "seller",
         isSeller: true,
-        isApproved: true
+        isApproved: true,
       });
-      
+
       if (!updatedUser) {
         return res.status(404).json({ message: "User not found" });
       }
-      
+
       // Simplify by just updating the user in the session directly
       req.user.role = "seller";
       req.user.isSeller = true;
       req.user.isApproved = true;
-      
+
       // Return user without password (using the updated session user)
       const { password, ...userWithoutPassword } = req.user;
       console.log("User updated to seller:", userWithoutPassword);
-      
+
       // Save the session to ensure changes persist
       req.session.save((err) => {
         if (err) {
@@ -212,7 +232,11 @@ export function setupAuth(app: Express) {
   });
 }
 
-export function isAuthenticated(req: Request, res: Response, next: NextFunction) {
+export function isAuthenticated(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+) {
   if (req.isAuthenticated()) {
     return next();
   }
@@ -223,7 +247,7 @@ export function isSeller(req: Request, res: Response, next: NextFunction) {
   console.log("isSeller check - User:", req.user);
   console.log("isAuthenticated:", req.isAuthenticated());
   console.log("isSeller value:", req.user?.isSeller);
-  
+
   if (req.isAuthenticated() && req.user.isSeller) {
     console.log("User is authenticated and is a seller, proceeding");
     return next();


### PR DESCRIPTION
## Summary
- ensure `req.login` waits for session save
- surface duplicate user errors with a clear message

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_6848610256a88330aff8a43fb94a6c0e