### PR TITLE
Fix auto-login and address persistence

### DIFF
--- a/client/src/pages/checkout-page.tsx
+++ b/client/src/pages/checkout-page.tsx
@@ -134,7 +134,9 @@ export default function CheckoutPage() {
       // Save or update shipping address
       try {
         if (selectedAddressId === "new") {
-          await apiRequest("POST", "/api/addresses", shippingInfo);
+          const createRes = await apiRequest("POST", "/api/addresses", shippingInfo);
+          const created = await createRes.json();
+          setSelectedAddressId(created.id);
         } else {
           await apiRequest(
             "PUT",


### PR DESCRIPTION
## Summary
- ensure session is saved after login and registration
- surface duplicate key errors by code
- retain newly created shipping address on checkout

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_6848610256a88330aff8a43fb94a6c0e