### PR TITLE
Avoid registration retry

### DIFF
--- a/client/src/hooks/use-auth.tsx
+++ b/client/src/hooks/use-auth.tsx
@@ -104,6 +104,10 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         variant: "destructive",
       });
     },
+    // Avoid retrying registration automatically to prevent duplicate requests
+    // which can lead to a "username already exists" error even when the first
+    // attempt succeeds.
+    retry: false,
   });
 
   const logoutMutation = useMutation({


### PR DESCRIPTION
## Summary
- disable retry on user registration to prevent double submissions

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_68486d206cb48330b8876897c52b191c