### PR TITLE
Redirect logged-in users away from splash home

### DIFF
--- a/client/src/pages/home-page.tsx
+++ b/client/src/pages/home-page.tsx
@@ -6,8 +6,33 @@ import Testimonials from "@/components/home/testimonials";
 import CTA from "@/components/home/cta";
 import Header from "@/components/layout/header-fixed";
 import Footer from "@/components/layout/footer-fixed";
+import { useAuth } from "@/hooks/use-auth";
+import { Redirect } from "wouter";
+import { Loader2 } from "lucide-react";
 
 export default function HomePage() {
+  const { user, isLoading } = useAuth();
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">
+        <Loader2 className="h-8 w-8 animate-spin text-primary" />
+      </div>
+    );
+  }
+
+  if (user) {
+    if (user.role === "seller") {
+      return <Redirect to="/seller/dashboard" />;
+    }
+    if (user.role === "buyer") {
+      return <Redirect to="/buyer/dashboard" />;
+    }
+    if (user.role === "admin") {
+      return <Redirect to="/admin/dashboard" />;
+    }
+  }
+
   return (
     <>
       <Header />


### PR DESCRIPTION
## Summary
- send logged-in users to the correct dashboard instead of the splash home page

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6848712440548330b7a77aaf559fc1fc