### PR TITLE
Integrate dashboard tabs with header

### DIFF
--- a/client/src/components/layout/header.tsx
+++ b/client/src/components/layout/header.tsx
@@ -21,8 +21,12 @@ import { Badge } from "@/components/ui/badge";
 import { useAuth } from "@/hooks/use-auth";
 import { useCart } from "@/hooks/use-cart";
 import CartDrawer from "@/components/cart/cart-drawer";
+import { ReactNode } from "react";
 
-export default function Header() {
+interface HeaderProps {
+  dashboardTabs?: ReactNode;
+}
+export default function Header({ dashboardTabs }: HeaderProps) {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [location] = useLocation();
   const { user, logoutMutation } = useAuth();
@@ -254,7 +258,15 @@ export default function Header() {
           </div>
         )}
       </header>
-      
+
+      {dashboardTabs && (
+        <div className="bg-gray-50 border-t">
+          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-2">
+            {dashboardTabs}
+          </div>
+        </div>
+      )}
+
       <CartDrawer />
     </>
   );

--- a/client/src/pages/admin/dashboard.tsx
+++ b/client/src/pages/admin/dashboard.tsx
@@ -77,7 +77,29 @@ export default function AdminDashboard() {
   
   return (
     <>
-      <Header />
+    <Tabs
+      defaultValue={activeTab}
+      onValueChange={setActiveTab}
+      className="space-y-6"
+    >
+      <Header
+        dashboardTabs={
+          <TabsList className="grid grid-cols-3 md:flex md:w-auto">
+            <TabsTrigger value="overview">
+              <LayoutDashboard className="h-4 w-4 mr-2" />
+              Overview
+            </TabsTrigger>
+            <TabsTrigger value="users">
+              <Users className="h-4 w-4 mr-2" />
+              Users
+            </TabsTrigger>
+            <TabsTrigger value="sales">
+              <BarChart4 className="h-4 w-4 mr-2" />
+              Sales
+            </TabsTrigger>
+          </TabsList>
+        }
+      />
       <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         <div className="flex items-center justify-between mb-6">
           <div>
@@ -109,23 +131,7 @@ export default function AdminDashboard() {
           </div>
         </div>
         
-        <Tabs defaultValue={activeTab} onValueChange={setActiveTab} className="space-y-6">
-          <TabsList className="grid grid-cols-3 md:flex md:w-auto">
-            <TabsTrigger value="overview">
-              <LayoutDashboard className="h-4 w-4 mr-2" />
-              Overview
-            </TabsTrigger>
-            <TabsTrigger value="users">
-              <Users className="h-4 w-4 mr-2" />
-              Users
-            </TabsTrigger>
-            <TabsTrigger value="sales">
-              <BarChart4 className="h-4 w-4 mr-2" />
-              Sales
-            </TabsTrigger>
-          </TabsList>
-          
-          <TabsContent value="overview" className="space-y-6">
+        <TabsContent value="overview" className="space-y-6">
             {isLoading ? (
               <div className="flex justify-center py-12">
                 <Loader2 className="h-12 w-12 animate-spin text-primary" />
@@ -554,9 +560,9 @@ export default function AdminDashboard() {
               </CardContent>
             </Card>
           </TabsContent>
-        </Tabs>
       </main>
-      <Footer />
-    </>
+    </Tabs>
+    <Footer />
+  </>
   );
 }

--- a/client/src/pages/buyer/dashboard.tsx
+++ b/client/src/pages/buyer/dashboard.tsx
@@ -57,7 +57,20 @@ export default function BuyerDashboard() {
   
   return (
     <>
-      <Header />
+    <Tabs
+      defaultValue={activeTab}
+      onValueChange={setActiveTab}
+      className="space-y-6"
+    >
+      <Header
+        dashboardTabs={
+          <TabsList className="grid grid-cols-3 md:flex md:w-auto">
+            <TabsTrigger value="overview">Overview</TabsTrigger>
+            <TabsTrigger value="orders">Orders</TabsTrigger>
+            <TabsTrigger value="profile">Profile</TabsTrigger>
+          </TabsList>
+        }
+      />
       <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         <div className="flex items-center justify-between mb-6">
           <div>
@@ -78,14 +91,7 @@ export default function BuyerDashboard() {
           </div>
         </div>
         
-        <Tabs defaultValue={activeTab} onValueChange={setActiveTab} className="space-y-6">
-          <TabsList className="grid grid-cols-3 md:flex md:w-auto">
-            <TabsTrigger value="overview">Overview</TabsTrigger>
-            <TabsTrigger value="orders">Orders</TabsTrigger>
-            <TabsTrigger value="profile">Profile</TabsTrigger>
-          </TabsList>
-          
-          <TabsContent value="overview" className="space-y-6">
+        <TabsContent value="overview" className="space-y-6">
             {/* Stats Cards */}
             <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
               <Card>
@@ -396,8 +402,8 @@ export default function BuyerDashboard() {
               </Card>
             </div>
           </TabsContent>
-        </Tabs>
       </main>
+      </Tabs>
       <Footer />
     </>
   );

--- a/client/src/pages/seller/dashboard.tsx
+++ b/client/src/pages/seller/dashboard.tsx
@@ -69,7 +69,20 @@ export default function SellerDashboard() {
   
   return (
     <>
-      <Header />
+    <Tabs
+      defaultValue={activeTab}
+      onValueChange={setActiveTab}
+      className="space-y-6"
+    >
+      <Header
+        dashboardTabs={
+          <TabsList className="grid grid-cols-3 md:flex md:w-auto">
+            <TabsTrigger value="overview">Overview</TabsTrigger>
+            <TabsTrigger value="orders">Orders</TabsTrigger>
+            <TabsTrigger value="profile">Profile</TabsTrigger>
+          </TabsList>
+        }
+      />
       <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         <div className="flex items-center justify-between mb-6">
           <div>
@@ -96,14 +109,7 @@ export default function SellerDashboard() {
           </div>
         </div>
         
-        <Tabs defaultValue={activeTab} onValueChange={setActiveTab} className="space-y-6">
-          <TabsList className="grid grid-cols-3 md:flex md:w-auto">
-            <TabsTrigger value="overview">Overview</TabsTrigger>
-            <TabsTrigger value="orders">Orders</TabsTrigger>
-            <TabsTrigger value="profile">Profile</TabsTrigger>
-          </TabsList>
-          
-          <TabsContent value="overview" className="space-y-6">
+        <TabsContent value="overview" className="space-y-6">
             {/* Stats Cards */}
             <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
               <Card>
@@ -488,9 +494,9 @@ export default function SellerDashboard() {
               </Card>
             </div>
           </TabsContent>
+        </main>
         </Tabs>
-      </main>
-      <Footer />
-    </>
+        <Footer />
+      </>
   );
 }


### PR DESCRIPTION
## Summary
- allow `Header` component to accept optional dashboard tabs
- render dashboard tabs below the main navigation when provided
- update buyer, seller and admin dashboards to pass their tab list to the `Header`

## Testing
- `npm run check` *(fails: Cannot find type definition file)*

------
https://chatgpt.com/codex/tasks/task_e_68487a424ee48330bfb171c0170fe798