### PR TITLE
Fix profile navigation and UI tweaks

### DIFF
--- a/client/src/components/products/product-card.tsx
+++ b/client/src/components/products/product-card.tsx
@@ -54,19 +54,14 @@ export default function ProductCard({ product }: ProductCardProps) {
             MOQ: {product.minOrderQuantity}
           </Badge>
         </div>
-        <div className="mt-3 flex gap-2">
-          <Button 
-            size="sm" 
+        <div className="mt-3">
+          <Button
+            size="sm"
             className="flex items-center"
             onClick={handleAddToCart}
           >
             <ShoppingCart className="mr-1 h-4 w-4" /> Add to Cart
           </Button>
-          <Link href={`/products/${product.id}`}>
-            <Button size="sm" variant="outline">
-              Details
-            </Button>
-          </Link>
         </div>
       </CardContent>
     </Card>

--- a/client/src/components/ui/sheet.tsx
+++ b/client/src/components/ui/sheet.tsx
@@ -94,7 +94,7 @@ const SheetFooter = ({
 }: React.HTMLAttributes<HTMLDivElement>) => (
   <div
     className={cn(
-      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      "flex flex-col-reverse sm:flex-row sm:justify-center sm:space-x-2",
       className
     )}
     {...props}

--- a/client/src/pages/buyer/dashboard.tsx
+++ b/client/src/pages/buyer/dashboard.tsx
@@ -1,6 +1,6 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { Link } from "wouter";
+import { Link, useLocation } from "wouter";
 import { Order, Product, Address, PaymentMethod } from "@shared/schema";
 import Header from "@/components/layout/header";
 import Footer from "@/components/layout/footer";
@@ -35,6 +35,14 @@ import OrderStatus from "@/components/buyer/order-status";
 export default function BuyerDashboard() {
   const { user } = useAuth();
   const [activeTab, setActiveTab] = useState("overview");
+  const [location] = useLocation();
+
+  useEffect(() => {
+    const hash = window.location.hash.replace("#", "");
+    if (hash) {
+      setActiveTab(hash);
+    }
+  }, [location]);
 
   const { data: orders = [], isLoading: isLoadingOrders } = useQuery<Order[]>({
     queryKey: ["/api/orders"],


### PR DESCRIPTION
## Summary
- remove Details button from product card
- center cart drawer footer buttons
- make profile dropdown link open the profile tab correctly by reading URL hash in buyer dashboard

## Testing
- `npm run check` *(fails: Cannot find type definition file)*

------
https://chatgpt.com/codex/tasks/task_e_6848eb9c790083309734ff27796bd9a3