### PR TITLE
Add seller order processing actions

### DIFF
--- a/server/email.ts
+++ b/server/email.ts
@@ -215,3 +215,27 @@ export async function sendSellerApprovalEmail(to: string) {
     console.error("Failed to send seller approval email", err);
   }
 }
+
+export async function sendOrderMessageEmail(
+  to: string,
+  orderId: number,
+  message: string,
+) {
+  if (!transporter) {
+    console.warn("Email transport not configured; skipping order message email");
+    return;
+  }
+
+  const mailOptions = {
+    from: process.env.SMTP_FROM || user,
+    to,
+    subject: `Message regarding Order #${orderId}`,
+    text: message,
+  };
+
+  try {
+    await transporter.sendMail(mailOptions);
+  } catch (err) {
+    console.error("Failed to send order message email", err);
+  }
+}


### PR DESCRIPTION
## Summary
- allow seller to cancel their orders
- send messages to buyers via new API endpoint
- expose server helper to email buyer messages
- let sellers update order status from dashboard and contact/cancel buyers

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_6848f20e564083308408e89a743ccdfd