### PR TITLE
Add order multiple support

### DIFF
--- a/client/src/components/cart/cart-item.tsx
+++ b/client/src/components/cart/cart-item.tsx
@@ -16,12 +16,12 @@ export default function CartItem({ item }: CartItemProps) {
       // If reducing would go below MOQ, remove the item
       removeFromCart(item.productId);
     } else {
-      updateQuantity(item.productId, item.quantity - 1);
+      updateQuantity(item.productId, item.quantity - item.orderMultiple);
     }
   };
-  
+
   const handleIncrease = () => {
-    updateQuantity(item.productId, item.quantity + 1);
+    updateQuantity(item.productId, item.quantity + item.orderMultiple);
   };
   
   const itemTotal = item.price * item.quantity;
@@ -57,7 +57,7 @@ export default function CartItem({ item }: CartItemProps) {
               size="icon" 
               className="h-7 w-7"
               onClick={handleDecrease}
-              disabled={item.quantity <= 1}
+              disabled={item.quantity <= item.minOrderQuantity}
             >
               <Minus className="h-3 w-3" />
             </Button>
@@ -67,7 +67,7 @@ export default function CartItem({ item }: CartItemProps) {
               size="icon" 
               className="h-7 w-7"
               onClick={handleIncrease}
-              disabled={item.quantity >= item.availableUnits}
+              disabled={item.quantity + item.orderMultiple > item.availableUnits}
             >
               <Plus className="h-3 w-3" />
             </Button>

--- a/client/src/components/products/product-card.tsx
+++ b/client/src/components/products/product-card.tsx
@@ -40,6 +40,7 @@ export default function ProductCard({ product }: ProductCardProps) {
         </p>
         <div className="text-xs text-gray-500 flex flex-wrap gap-x-2">
           <span>MOQ: {product.minOrderQuantity}</span>
+          <span>Order by {product.orderMultiple}</span>
           <span>{product.availableUnits} avail.</span>
           <span>{product.condition}</span>
         </div>

--- a/client/src/components/seller/product-form.tsx
+++ b/client/src/components/seller/product-form.tsx
@@ -69,6 +69,7 @@ export default function ProductForm({ product, onSuccess }: ProductFormProps) {
       totalUnits: typeof product.totalUnits === 'number' && !isNaN(product.totalUnits) ? product.totalUnits : 0,
       availableUnits: typeof product.availableUnits === 'number' && !isNaN(product.availableUnits) ? product.availableUnits : 0,
       minOrderQuantity: typeof product.minOrderQuantity === 'number' && !isNaN(product.minOrderQuantity) ? product.minOrderQuantity : 1,
+      orderMultiple: typeof (product as any).orderMultiple === 'number' && !isNaN((product as any).orderMultiple) ? (product as any).orderMultiple : 1,
       fobLocation: product.fobLocation || '',
       retailComparisonUrl: product.retailComparisonUrl || '',
       upc: product.upc || '',
@@ -82,6 +83,7 @@ export default function ProductForm({ product, onSuccess }: ProductFormProps) {
       totalUnits: 0,
       availableUnits: 0,
       minOrderQuantity: 1,
+      orderMultiple: 1,
       images: [],
       fobLocation: "",
       retailComparisonUrl: "",
@@ -155,6 +157,7 @@ export default function ProductForm({ product, onSuccess }: ProductFormProps) {
       totalUnits: typeof data.totalUnits === 'string' ? parseInt(data.totalUnits) : data.totalUnits,
       availableUnits: typeof data.availableUnits === 'string' ? parseInt(data.availableUnits) : data.availableUnits,
       minOrderQuantity: typeof data.minOrderQuantity === 'string' ? parseInt(data.minOrderQuantity) : data.minOrderQuantity,
+      orderMultiple: typeof (data as any).orderMultiple === 'string' ? parseInt((data as any).orderMultiple) : (data as any).orderMultiple,
     };
     
     // Check for NaN values and replace with defaults
@@ -162,6 +165,7 @@ export default function ProductForm({ product, onSuccess }: ProductFormProps) {
     if (isNaN(formattedData.totalUnits)) formattedData.totalUnits = 0;
     if (isNaN(formattedData.availableUnits)) formattedData.availableUnits = 0;
     if (isNaN(formattedData.minOrderQuantity)) formattedData.minOrderQuantity = 1;
+    if (isNaN((formattedData as any).orderMultiple)) (formattedData as any).orderMultiple = 1;
     
     console.log("Formatted data for submission:", formattedData);
     try {
@@ -456,6 +460,32 @@ export default function ProductForm({ product, onSuccess }: ProductFormProps) {
                 </FormControl>
                 <FormDescription>
                   Minimum number of units per order.
+                </FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="orderMultiple"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Order By Quantity</FormLabel>
+                <FormControl>
+                  <Input
+                    type="number"
+                    min="1"
+                    placeholder="1"
+                    {...field}
+                    onChange={(e) => {
+                      const value = e.target.value;
+                      field.onChange(value === "" ? 0 : parseInt(value));
+                    }}
+                  />
+                </FormControl>
+                <FormDescription>
+                  Buyers must order in multiples of this amount.
                 </FormDescription>
                 <FormMessage />
               </FormItem>

--- a/client/src/pages/product-detail-page.tsx
+++ b/client/src/pages/product-detail-page.tsx
@@ -46,13 +46,13 @@ export default function ProductDetailPage() {
 
   const handleDecrease = () => {
     if (product && quantity > product.minOrderQuantity) {
-      setQuantity(quantity - 1);
+      setQuantity(quantity - product.orderMultiple);
     }
   };
 
   const handleIncrease = () => {
-    if (product && quantity < product.availableUnits) {
-      setQuantity(quantity + 1);
+    if (product && quantity + product.orderMultiple <= product.availableUnits) {
+      setQuantity(quantity + product.orderMultiple);
     }
   };
 
@@ -156,7 +156,7 @@ export default function ProductDetailPage() {
 
             <div className="text-3xl font-bold mb-2">{formatCurrency(product.price)} <span className="text-sm font-normal text-gray-500">/unit</span></div>
             <div className="text-sm text-gray-600 mb-1"><Package className="inline-block h-4 w-4 mr-1" />{product.availableUnits} units</div>
-            <div className="text-sm text-gray-600 mb-1"><Layers className="inline-block h-4 w-4 mr-1" />Minimum {product.minOrderQuantity}</div>
+            <div className="text-sm text-gray-600 mb-1"><Layers className="inline-block h-4 w-4 mr-1" />Minimum {product.minOrderQuantity} (by {product.orderMultiple})</div>
             {product.fobLocation && (
               <div className="text-sm text-gray-600 mb-4"><Truck className="inline-block h-4 w-4 mr-1" />Ships from {product.fobLocation}</div>
             )}
@@ -166,7 +166,7 @@ export default function ProductDetailPage() {
                 <Minus className="h-4 w-4" />
               </Button>
               <div className="w-10 text-center">{quantity}</div>
-              <Button variant="outline" size="icon" onClick={handleIncrease} disabled={quantity >= product.availableUnits}>
+              <Button variant="outline" size="icon" onClick={handleIncrease} disabled={quantity + product.orderMultiple > product.availableUnits}>
                 <Plus className="h-4 w-4" />
               </Button>
             </div>

--- a/client/src/pages/seller/products.tsx
+++ b/client/src/pages/seller/products.tsx
@@ -285,6 +285,7 @@ export default function SellerProducts() {
                       <TableHead>Category</TableHead>
                       <TableHead>Price</TableHead>
                       <TableHead>MOQ</TableHead>
+                      <TableHead>Order By</TableHead>
                       <TableHead>Available</TableHead>
                       <TableHead>Total Units</TableHead>
                       <TableHead>Actions</TableHead>
@@ -306,6 +307,7 @@ export default function SellerProducts() {
                         <TableCell>{product.category}</TableCell>
                         <TableCell>{formatCurrency(product.price)}</TableCell>
                         <TableCell>{product.minOrderQuantity}</TableCell>
+                        <TableCell>{product.orderMultiple}</TableCell>
                         <TableCell>
                           <div className="flex items-center">
                             {product.availableUnits > 0 ? (

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -108,6 +108,7 @@ export const products = pgTable("products", {
   totalUnits: integer("total_units").notNull(),
   availableUnits: integer("available_units").notNull(),
   minOrderQuantity: integer("min_order_quantity").notNull(),
+  orderMultiple: integer("order_multiple").notNull().default(1),
   images: text("images").array().notNull(),
   fobLocation: text("fob_location"),
   retailComparisonUrl: text("retail_comparison_url"),
@@ -138,6 +139,7 @@ export const insertProductSchema = createInsertSchema(products, {
     // Images are optional for testing but an empty array will be stored
     images: z.array(z.string()).default([]),
     isBanner: z.boolean().optional(),
+    orderMultiple: z.coerce.number().int().positive().default(1)
   });
 
 // Order schema
@@ -285,5 +287,6 @@ export interface CartItem {
   quantity: number;
   image: string;
   minOrderQuantity: number;
+  orderMultiple: number;
   availableUnits: number;
 }


### PR DESCRIPTION
## Summary
- add `orderMultiple` to product schema and cart item type
- allow sellers to specify order multiple in product form
- display order multiple in product card and seller product list
- enforce order multiple when adding/updating cart and on product page

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_6849bafcc5a88330b0320b9880680ac2