### PR TITLE
Fix product detail image scaling

### DIFF
--- a/client/src/pages/product-detail-page.tsx
+++ b/client/src/pages/product-detail-page.tsx
@@ -133,7 +133,7 @@ export default function ProductDetailPage() {
                       <img
                         src={image}
                         alt={`Image ${index + 1}`}
-                        className="rounded-lg w-full object-cover aspect-square"
+                        className="rounded-lg w-full object-contain aspect-square"
                       />
                     </CarouselItem>
                   ))}
@@ -145,7 +145,7 @@ export default function ProductDetailPage() {
               <img
                 src={product.images[0]}
                 alt={product.title}
-                className="rounded-lg w-full object-cover aspect-square"
+                className="rounded-lg w-full object-contain aspect-square"
               />
             )}
           </div>


### PR DESCRIPTION
## Summary
- ensure product detail images use `object-contain` so they scale to fit the square container

## Testing
- `npm run check` *(fails: Cannot find type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_6849caeb37c4833095884c5aef32dcd5