### PR TITLE
Require seller approval before dashboard access

### DIFF
--- a/client/src/pages/auth-page.tsx
+++ b/client/src/pages/auth-page.tsx
@@ -48,7 +48,11 @@ export default function AuthPage() {
       if (user.role === "admin") {
         setLocation("/admin/dashboard");
       } else if (user.role === "seller") {
-        setLocation("/seller/dashboard");
+        if (user.isSeller && user.isApproved) {
+          setLocation("/seller/dashboard");
+        } else {
+          setLocation("/seller/apply");
+        }
       } else {
         setLocation("/buyer/home");
       }

--- a/client/src/pages/seller/dashboard.tsx
+++ b/client/src/pages/seller/dashboard.tsx
@@ -41,7 +41,14 @@ import { formatCurrency, formatDate } from "@/lib/utils";
 export default function SellerDashboard() {
   const { user } = useAuth();
   const [activeTab, setActiveTab] = useState("overview");
-  const [location] = useLocation();
+  const [location, setLocation] = useLocation();
+
+  useEffect(() => {
+    if (user?.role === "seller" && (!user.isSeller || !user.isApproved)) {
+      setLocation("/seller/apply");
+      return;
+    }
+  }, [user, setLocation]);
 
   useEffect(() => {
     const hash = window.location.hash.replace("#", "");

--- a/client/src/pages/seller/products.tsx
+++ b/client/src/pages/seller/products.tsx
@@ -53,6 +53,12 @@ import { useAuth } from "@/hooks/use-auth";
 export default function SellerProducts() {
   const [, setLocation] = useLocation();
   const { user } = useAuth();
+
+  useEffect(() => {
+    if (user?.role === "seller" && (!user.isSeller || !user.isApproved)) {
+      setLocation("/seller/apply");
+    }
+  }, [user, setLocation]);
   const { toast } = useToast();
   const queryClient = useQueryClient();
   const [searchTerm, setSearchTerm] = useState("");


### PR DESCRIPTION
## Summary
- redirect sellers without approval to the application page
- protect seller dashboard and product pages from unapproved sellers

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*
- `npm install` *(fails: 403 Forbidden fetching dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6849cd4316408330ab331235ba56104b