### PR TITLE
Add message system with notifications

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -22,6 +22,7 @@ import SellerDashboard from "@/pages/seller/dashboard";
 import SellerProducts from "@/pages/seller/products";
 import SellerOrdersPage from "@/pages/seller/orders";
 import SellerApply from "@/pages/seller/apply";
+import OrderMessagesPage from "@/pages/order-messages";
 import AdminDashboard from "@/pages/admin/dashboard";
 import FeaturedProductsPage from "@/pages/admin/featured-products";
 import AdminUsers from "@/pages/admin/users";
@@ -54,6 +55,8 @@ function Router() {
       <ProtectedRoute path="/seller/dashboard" component={SellerDashboard} allowedRoles={["seller", "admin"]} />
       <ProtectedRoute path="/seller/products" component={SellerProducts} allowedRoles={["seller", "admin"]} />
       <ProtectedRoute path="/seller/orders" component={SellerOrdersPage} allowedRoles={["seller", "admin"]} />
+
+      <ProtectedRoute path="/orders/:id/messages" component={OrderMessagesPage} allowedRoles={["buyer", "seller", "admin"]} />
 
       {/* Admin routes */}
       <ProtectedRoute path="/admin/dashboard" component={AdminDashboard} allowedRoles={["admin"]} />

--- a/client/src/components/layout/header-fixed.tsx
+++ b/client/src/components/layout/header-fixed.tsx
@@ -20,6 +20,7 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { useAuth } from "@/hooks/use-auth";
 import { useCart } from "@/hooks/use-cart";
+import { useUnreadMessages } from "@/hooks/use-messages";
 import CartDrawer from "@/components/cart/cart-drawer";
 import MobileNav from "@/components/layout/mobile-nav";
 
@@ -27,6 +28,7 @@ export default function Header() {
   const [location] = useLocation();
   const { user, logoutMutation } = useAuth();
   const { itemCount, setIsCartOpen } = useCart();
+  const unread = useUnreadMessages();
   const [isMenuOpen, setIsMenuOpen] = useState(false);
 
   const isActive = (path: string) => {
@@ -98,13 +100,17 @@ export default function Header() {
               </Button>
               
               {user && (
-                <Button variant="ghost" size="icon" className="text-gray-400 hover:text-gray-500 relative">
-                  <Bell className="h-5 w-5" />
-                  <Badge className="absolute -top-2 -right-2 bg-primary text-white text-xs h-5 w-5 flex items-center justify-center p-0">
-                    2
-                  </Badge>
-                  <span className="sr-only">Notifications</span>
-                </Button>
+                <Link href={user.role === "buyer" ? "/buyer/orders" : "/seller/orders"}>
+                  <Button variant="ghost" size="icon" className="text-gray-400 hover:text-gray-500 relative">
+                    <Bell className="h-5 w-5" />
+                    {unread > 0 && (
+                      <Badge className="absolute -top-2 -right-2 bg-primary text-white text-xs h-5 w-5 flex items-center justify-center p-0">
+                        {unread}
+                      </Badge>
+                    )}
+                    <span className="sr-only">Notifications</span>
+                  </Button>
+                </Link>
               )}
               
               {user ? (
@@ -215,16 +221,20 @@ export default function Header() {
                     <div className="text-sm font-medium text-gray-500">{user.email}</div>
                   </div>
                   <div className="ml-auto flex space-x-4">
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      className="text-gray-400 hover:text-gray-500 relative"
-                    >
-                      <Bell className="h-5 w-5" />
-                      <Badge className="absolute -top-2 -right-2 bg-primary text-white text-xs h-5 w-5 flex items-center justify-center p-0">
-                        2
-                      </Badge>
-                    </Button>
+                    <Link href={user.role === "buyer" ? "/buyer/orders" : "/seller/orders"}>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="text-gray-400 hover:text-gray-500 relative"
+                      >
+                        <Bell className="h-5 w-5" />
+                        {unread > 0 && (
+                          <Badge className="absolute -top-2 -right-2 bg-primary text-white text-xs h-5 w-5 flex items-center justify-center p-0">
+                            {unread}
+                          </Badge>
+                        )}
+                      </Button>
+                    </Link>
                     <Button
                       variant="ghost"
                       size="icon"

--- a/client/src/components/layout/header.tsx
+++ b/client/src/components/layout/header.tsx
@@ -20,6 +20,7 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { useAuth } from "@/hooks/use-auth";
 import { useCart } from "@/hooks/use-cart";
+import { useUnreadMessages } from "@/hooks/use-messages";
 import CartDrawer from "@/components/cart/cart-drawer";
 import MobileNav from "@/components/layout/mobile-nav";
 import { ReactNode } from "react";
@@ -34,6 +35,7 @@ export default function Header({ dashboardTabs, onProfileClick }: HeaderProps) {
   const [location] = useLocation();
   const { user, logoutMutation } = useAuth();
   const { itemCount, setIsCartOpen } = useCart();
+  const unread = useUnreadMessages();
 
   const handleLogout = () => logoutMutation.mutate();
   const isActive = (path: string) => location === path;
@@ -108,12 +110,16 @@ export default function Header({ dashboardTabs, onProfileClick }: HeaderProps) {
               </Button>
 
               {user && (
-                <Button variant="ghost" size="icon" className="text-gray-400 hover:text-gray-500 relative">
-                  <Bell className="h-5 w-5" />
-                  <Badge className="absolute -top-2 -right-2 bg-primary text-white text-xs h-5 w-5 flex items-center justify-center p-0">
-                    2
-                  </Badge>
-                </Button>
+                <Link href={user.role === "buyer" ? "/buyer/orders" : "/seller/orders"}>
+                  <Button variant="ghost" size="icon" className="text-gray-400 hover:text-gray-500 relative">
+                    <Bell className="h-5 w-5" />
+                    {unread > 0 && (
+                      <Badge className="absolute -top-2 -right-2 bg-primary text-white text-xs h-5 w-5 flex items-center justify-center p-0">
+                        {unread}
+                      </Badge>
+                    )}
+                  </Button>
+                </Link>
               )}
 
               {user ? (

--- a/client/src/hooks/use-messages.tsx
+++ b/client/src/hooks/use-messages.tsx
@@ -1,0 +1,32 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { apiRequest } from "@/lib/queryClient";
+import { Message } from "@shared/schema";
+
+export function useMessages(orderId: number) {
+  const queryClient = useQueryClient();
+
+  const messagesQuery = useQuery<Message[]>({
+    queryKey: ["/api/orders/" + orderId + "/messages"],
+    enabled: !!orderId,
+  });
+
+  const sendMessage = useMutation({
+    mutationFn: (content: string) =>
+      apiRequest("POST", `/api/orders/${orderId}/messages`, { message: content }).then(r => r.json()),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["/api/orders/" + orderId + "/messages"] }),
+  });
+
+  const markRead = useMutation({
+    mutationFn: () => apiRequest("POST", `/api/orders/${orderId}/messages/read`),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["/api/messages/unread-count"] }),
+  });
+
+  return { ...messagesQuery, sendMessage, markRead };
+}
+
+export function useUnreadMessages() {
+  const { data } = useQuery<{ count: number }>({
+    queryKey: ["/api/messages/unread-count"],
+  });
+  return data?.count ?? 0;
+}

--- a/client/src/pages/buyer/orders.tsx
+++ b/client/src/pages/buyer/orders.tsx
@@ -157,6 +157,9 @@ export default function BuyerOrdersPage() {
                       <Button variant="outline" size="sm">
                         Download Invoice
                       </Button>
+                      <Button variant="outline" size="sm" asChild>
+                        <Link href={`/orders/${order.id}/messages`}>Message Seller</Link>
+                      </Button>
                     </div>
                   </div>
                 ))}

--- a/client/src/pages/order-messages.tsx
+++ b/client/src/pages/order-messages.tsx
@@ -1,0 +1,59 @@
+import { useParams } from "wouter";
+import Header from "@/components/layout/header";
+import Footer from "@/components/layout/footer";
+import { useMessages } from "@/hooks/use-messages";
+import { useAuth } from "@/hooks/use-auth";
+import { useEffect, useRef } from "react";
+import { format } from "date-fns";
+
+export default function OrderMessagesPage() {
+  const { id } = useParams();
+  const orderId = parseInt(id);
+  const { user } = useAuth();
+  const { data: messages = [], isLoading, sendMessage, markRead } = useMessages(orderId);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (orderId) {
+      markRead.mutate();
+    }
+  }, [orderId]);
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const value = inputRef.current?.value.trim();
+    if (!value) return;
+    sendMessage.mutate(value);
+    if (inputRef.current) inputRef.current.value = "";
+  }
+
+  return (
+    <>
+      <Header />
+      <main className="max-w-2xl mx-auto px-4 py-8 space-y-4">
+        <h1 className="text-2xl font-bold">Messages</h1>
+        <div className="border rounded p-4 h-80 overflow-y-auto space-y-2 bg-gray-50">
+          {isLoading ? (
+            <p>Loading...</p>
+          ) : (
+            messages.map(m => (
+              <div key={m.id} className={m.senderId === user?.id ? "text-right" : "text-left"}>
+                <div className="inline-block bg-white px-3 py-1 rounded-md">
+                  {m.content}
+                </div>
+                <div className="text-xs text-gray-500">
+                  {format(new Date(m.createdAt), "PP p")}
+                </div>
+              </div>
+            ))
+          )}
+        </div>
+        <form onSubmit={handleSubmit} className="flex gap-2">
+          <input ref={inputRef} className="flex-1 border rounded px-2 py-1" placeholder="Type a message" />
+          <button type="submit" className="bg-primary text-white px-4 rounded">Send</button>
+        </form>
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/client/src/pages/seller/dashboard.tsx
+++ b/client/src/pages/seller/dashboard.tsx
@@ -106,7 +106,7 @@ export default function SellerDashboard() {
 
   const messageBuyer = useMutation({
     mutationFn: ({ id, message }: { id: number; message: string }) =>
-      apiRequest("POST", `/api/orders/${id}/message`, { message }),
+      apiRequest("POST", `/api/orders/${id}/messages`, { message }),
     onSuccess: () => toast({ title: "Message sent" }),
     onError: (err: Error) =>
       toast({ title: "Failed to send message", description: err.message, variant: "destructive" }),
@@ -396,6 +396,9 @@ export default function SellerDashboard() {
                           </Button>
                           <Button variant="outline" size="sm" onClick={() => handleContactBuyer(order.id)}>
                             Contact Buyer
+                          </Button>
+                          <Button variant="outline" size="sm" asChild>
+                            <Link href={`/orders/${order.id}/messages`}>Messages</Link>
                           </Button>
                         </div>
                       </div>

--- a/client/src/pages/seller/orders.tsx
+++ b/client/src/pages/seller/orders.tsx
@@ -58,7 +58,7 @@ export default function SellerOrdersPage() {
 
   const messageBuyer = useMutation({
     mutationFn: ({ id, message }: { id: number; message: string }) =>
-      apiRequest("POST", `/api/orders/${id}/message`, { message }),
+      apiRequest("POST", `/api/orders/${id}/messages`, { message }),
     onSuccess: () => toast({ title: "Message sent" }),
     onError: (err: Error) =>
       toast({ title: "Failed to send message", description: err.message, variant: "destructive" }),
@@ -177,6 +177,9 @@ export default function SellerOrdersPage() {
                       </Button>
                       <Button variant="outline" size="sm" onClick={() => handleContactBuyer(order.id)}>
                         Contact Buyer
+                      </Button>
+                      <Button variant="outline" size="sm" asChild>
+                        <Link href={`/orders/${order.id}/messages`}>Messages</Link>
                       </Button>
                     </div>
                   </div>

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -358,7 +358,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
-  app.post("/api/orders/:id/message", isAuthenticated, async (req, res) => {
+  app.post("/api/orders/:id/messages", isAuthenticated, async (req, res) => {
     try {
       const id = parseInt(req.params.id, 10);
       if (Number.isNaN(id)) {
@@ -371,17 +371,78 @@ export async function registerRoutes(app: Express): Promise<Server> {
         return res.status(404).json({ message: "Order not found" });
       }
 
-      if (order.sellerId !== user.id && user.role !== "admin") {
+      if (order.buyerId !== user.id && order.sellerId !== user.id && user.role !== "admin") {
         return res.status(403).json({ message: "Forbidden" });
       }
 
-      const buyer = await storage.getUser(order.buyerId);
-      if (!buyer) {
-        return res.status(404).json({ message: "Buyer not found" });
+      const receiverId = user.id === order.buyerId ? order.sellerId : order.buyerId;
+      const receiver = await storage.getUser(receiverId);
+      if (!receiver) {
+        return res.status(404).json({ message: "Receiver not found" });
       }
 
-      await sendOrderMessageEmail(buyer.email, order.id, req.body.message);
+      const message = await storage.createMessage({
+        orderId: order.id,
+        senderId: user.id,
+        receiverId,
+        content: req.body.message,
+      });
+
+      await sendOrderMessageEmail(receiver.email, order.id, req.body.message);
+      res.status(201).json(message);
+    } catch (error) {
+      handleApiError(res, error);
+    }
+  });
+
+  app.get("/api/orders/:id/messages", isAuthenticated, async (req, res) => {
+    try {
+      const id = parseInt(req.params.id, 10);
+      if (Number.isNaN(id)) {
+        return res.status(400).json({ message: "Invalid order ID" });
+      }
+      const user = req.user as Express.User;
+      const order = await storage.getOrder(id);
+      if (!order) {
+        return res.status(404).json({ message: "Order not found" });
+      }
+      if (order.buyerId !== user.id && order.sellerId !== user.id && user.role !== "admin") {
+        return res.status(403).json({ message: "Forbidden" });
+      }
+      const msgs = await storage.getOrderMessages(id);
+      res.json(msgs);
+    } catch (error) {
+      handleApiError(res, error);
+    }
+  });
+
+  app.post("/api/orders/:id/messages/read", isAuthenticated, async (req, res) => {
+    try {
+      const id = parseInt(req.params.id, 10);
+      if (Number.isNaN(id)) {
+        return res.status(400).json({ message: "Invalid order ID" });
+      }
+      const user = req.user as Express.User;
+      const order = await storage.getOrder(id);
+      if (!order) {
+        return res.status(404).json({ message: "Order not found" });
+      }
+      if (order.buyerId !== user.id && order.sellerId !== user.id && user.role !== "admin") {
+        return res.status(403).json({ message: "Forbidden" });
+      }
+
+      await storage.markMessagesAsRead(id, user.id);
       res.sendStatus(204);
+    } catch (error) {
+      handleApiError(res, error);
+    }
+  });
+
+  app.get("/api/messages/unread-count", isAuthenticated, async (req, res) => {
+    try {
+      const user = req.user as Express.User;
+      const count = await storage.getUnreadMessageCount(user.id);
+      res.json({ count });
     } catch (error) {
       handleApiError(res, error);
     }

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -254,6 +254,26 @@ export const insertCartSchema = createInsertSchema(carts)
     updatedAt: true,
   });
 
+// Messages between buyer and seller about an order
+export const messages = pgTable("messages", {
+  id: serial("id").primaryKey(),
+  orderId: integer("order_id").notNull(),
+  senderId: integer("sender_id").notNull(),
+  receiverId: integer("receiver_id").notNull(),
+  content: text("content").notNull(),
+  isRead: boolean("is_read").default(false),
+  createdAt: timestamp("created_at").defaultNow(),
+});
+
+export const messagesRelations = relations(messages, ({ one }) => ({
+  order: one(orders, { fields: [messages.orderId], references: [orders.id] }),
+  sender: one(users, { fields: [messages.senderId], references: [users.id] }),
+  receiver: one(users, { fields: [messages.receiverId], references: [users.id] }),
+}));
+
+export const insertMessageSchema = createInsertSchema(messages)
+  .omit({ id: true, isRead: true, createdAt: true });
+
 // Type definitions
 export type User = typeof users.$inferSelect;
 export type InsertUser = z.infer<typeof insertUserSchema>;
@@ -278,6 +298,9 @@ export type InsertAddress = z.infer<typeof insertAddressSchema>;
 
 export type PaymentMethod = typeof paymentMethods.$inferSelect;
 export type InsertPaymentMethod = z.infer<typeof insertPaymentMethodSchema>;
+
+export type Message = typeof messages.$inferSelect;
+export type InsertMessage = z.infer<typeof insertMessageSchema>;
 
 // Cart item interface for the frontend
 export interface CartItem {


### PR DESCRIPTION
## Summary
- add messages table and types
- implement message CRUD in storage and API routes
- show notifications for unread messages in both headers
- create hooks and pages for messaging
- link to messages from order lists

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node' and 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_6849cfc3443c833094387d90eaa4afc6