### PR TITLE
Improve messaging UI

### DIFF
--- a/client/src/components/messages/chat-message.tsx
+++ b/client/src/components/messages/chat-message.tsx
@@ -1,0 +1,26 @@
+import { Message } from "@shared/schema";
+import { format } from "date-fns";
+
+interface ChatMessageProps {
+  message: Message;
+  isOwn: boolean;
+}
+
+export default function ChatMessage({ message, isOwn }: ChatMessageProps) {
+  return (
+    <div className={`flex ${isOwn ? "justify-end" : "justify-start"}`}>
+      <div
+        className={`max-w-[70%] px-3 py-2 rounded-lg shadow-sm text-sm whitespace-pre-wrap break-words ${
+          isOwn
+            ? "bg-primary text-white rounded-br-none"
+            : "bg-gray-100 rounded-bl-none"
+        }`}
+      >
+        {message.content}
+        <div className="text-[10px] text-gray-500 mt-1 text-right">
+          {format(new Date(message.createdAt), "p")}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/client/src/pages/buyer/messages.tsx
+++ b/client/src/pages/buyer/messages.tsx
@@ -25,7 +25,7 @@ export default function BuyerMessagesPage() {
             {orders.map((o) => (
               <div
                 key={o.id}
-                className="border rounded p-4 flex justify-between items-center"
+                className="border rounded p-4 flex justify-between items-center bg-white shadow"
               >
                 <span>Order #{o.id}</span>
                 <Link href={`/orders/${o.id}/messages`}>

--- a/client/src/pages/order-messages.tsx
+++ b/client/src/pages/order-messages.tsx
@@ -4,7 +4,7 @@ import Footer from "@/components/layout/footer";
 import { useMessages } from "@/hooks/use-messages";
 import { useAuth } from "@/hooks/use-auth";
 import { useEffect, useRef } from "react";
-import { format } from "date-fns";
+import ChatMessage from "@/components/messages/chat-message";
 
 export default function OrderMessagesPage() {
   const { id } = useParams();
@@ -12,12 +12,17 @@ export default function OrderMessagesPage() {
   const { user } = useAuth();
   const { data: messages = [], isLoading, sendMessage, markRead } = useMessages(orderId);
   const inputRef = useRef<HTMLInputElement>(null);
+  const bottomRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (orderId) {
       markRead.mutate();
     }
   }, [orderId]);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages]);
 
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -30,23 +35,30 @@ export default function OrderMessagesPage() {
   return (
     <>
       <Header />
-      <main className="max-w-2xl mx-auto px-4 py-8 space-y-4">
-        <h1 className="text-2xl font-bold">Messages</h1>
-        <div className="border rounded p-4 h-80 overflow-y-auto space-y-2 bg-gray-50">
+      <main className="max-w-2xl mx-auto px-4 py-4 flex flex-col h-[calc(100vh-8rem)]">
+        <h1 className="text-xl font-semibold mb-2">Order Messages</h1>
+        <div className="flex-1 overflow-y-auto space-y-2 bg-gray-50 border rounded p-4">
           {isLoading ? (
             <p>Loading...</p>
           ) : (
-            messages.map((m) => (
-              <div key={m.id} className={m.senderId === user?.id ? "flex justify-end" : "flex justify-start"}>
-                <div className={`max-w-xs px-3 py-2 rounded-lg ${m.senderId === user?.id ? "bg-primary text-white" : "bg-white"}`}>{m.content}</div>
-                <div className="text-xs text-gray-500 self-end ml-2">{format(new Date(m.createdAt), "PP p")}</div>
-              </div>
+            messages.map(m => (
+              <ChatMessage key={m.id} message={m} isOwn={m.senderId === user?.id} />
             ))
           )}
+          <div ref={bottomRef} />
         </div>
-        <form onSubmit={handleSubmit} className="flex gap-2">
-          <input ref={inputRef} className="flex-1 border rounded px-2 py-1" placeholder="Type a message" />
-          <button type="submit" className="bg-primary text-white px-4 rounded">Send</button>
+        <form onSubmit={handleSubmit} className="mt-2 flex gap-2">
+          <input
+            ref={inputRef}
+            className="flex-1 border rounded-full px-3 py-2"
+            placeholder="Type a message"
+          />
+          <button
+            type="submit"
+            className="bg-primary text-white px-4 rounded-full"
+          >
+            Send
+          </button>
         </form>
       </main>
       <Footer />

--- a/client/src/pages/seller/messages.tsx
+++ b/client/src/pages/seller/messages.tsx
@@ -27,7 +27,7 @@ export default function SellerMessagesPage() {
           ) : questions.length > 0 ? (
             <div className="space-y-4">
               {questions.map((q) => (
-                <div key={q.id} className="border rounded p-4">
+                <div key={q.id} className="border rounded p-4 bg-white shadow">
                   <p className="font-medium">Product #{q.productId}</p>
                   <p className="text-gray-700 mb-1">{q.question}</p>
                   <p className="text-xs text-gray-500">Buyer #{q.buyerId}</p>
@@ -43,7 +43,7 @@ export default function SellerMessagesPage() {
           {orders.length > 0 ? (
             <div className="space-y-4">
               {orders.map((o) => (
-                <div key={o.id} className="border rounded p-4 flex justify-between items-center">
+                <div key={o.id} className="border rounded p-4 flex justify-between items-center bg-white shadow">
                   <span>Order #{o.id}</span>
                   <Link href={`/orders/${o.id}/messages`}>
                     <Button variant="outline" size="sm">View Messages</Button>


### PR DESCRIPTION
## Summary
- add `ChatMessage` for WhatsApp-style bubbles
- redesign the order conversation page
- tweak buyer and seller message pages

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_6852cf56f4cc8330a3063eb00c1278c8