### PR TITLE
Improve messaging UI

### DIFF
--- a/client/src/components/layout/header-fixed.tsx
+++ b/client/src/components/layout/header-fixed.tsx
@@ -1,10 +1,10 @@
 import { useState } from "react";
 import { Link, useLocation } from "wouter";
 import { 
-  Search, 
-  ShoppingCart, 
-  Bell, 
-  Menu, 
+  Search,
+  ShoppingCart,
+  MessageCircle,
+  Menu,
   X,
   User as UserIcon,
   LogOut
@@ -102,13 +102,13 @@ export default function Header() {
               {user && (
                 <Link href={user.role === "buyer" ? "/buyer/messages" : "/seller/messages"}>
                   <Button variant="ghost" size="icon" className="text-gray-400 hover:text-gray-500 relative">
-                    <Bell className="h-5 w-5" />
+                    <MessageCircle className="h-5 w-5" />
                     {unread > 0 && (
                       <Badge className="absolute -top-2 -right-2 bg-primary text-white text-xs h-5 w-5 flex items-center justify-center p-0">
                         {unread}
                       </Badge>
                     )}
-                    <span className="sr-only">Notifications</span>
+                    <span className="sr-only">Messages</span>
                   </Button>
                 </Link>
               )}
@@ -227,12 +227,13 @@ export default function Header() {
                         size="icon"
                         className="text-gray-400 hover:text-gray-500 relative"
                       >
-                        <Bell className="h-5 w-5" />
+                        <MessageCircle className="h-5 w-5" />
                         {unread > 0 && (
                           <Badge className="absolute -top-2 -right-2 bg-primary text-white text-xs h-5 w-5 flex items-center justify-center p-0">
                             {unread}
                           </Badge>
                         )}
+                        <span className="sr-only">Messages</span>
                       </Button>
                     </Link>
                     <Button

--- a/client/src/components/layout/header.tsx
+++ b/client/src/components/layout/header.tsx
@@ -3,7 +3,7 @@ import { Link, useLocation } from "wouter";
 import {
   Search,
   ShoppingCart,
-  Bell,
+  MessageCircle,
   Menu,
   X,
   User as UserIcon,
@@ -112,12 +112,13 @@ export default function Header({ dashboardTabs, onProfileClick }: HeaderProps) {
               {user && (
                 <Link href={user.role === "buyer" ? "/buyer/messages" : "/seller/messages"}>
                   <Button variant="ghost" size="icon" className="text-gray-400 hover:text-gray-500 relative">
-                    <Bell className="h-5 w-5" />
+                    <MessageCircle className="h-5 w-5" />
                     {unread > 0 && (
                       <Badge className="absolute -top-2 -right-2 bg-primary text-white text-xs h-5 w-5 flex items-center justify-center p-0">
                         {unread}
                       </Badge>
                     )}
+                    <span className="sr-only">Messages</span>
                   </Button>
                 </Link>
               )}

--- a/client/src/components/layout/mobile-nav.tsx
+++ b/client/src/components/layout/mobile-nav.tsx
@@ -1,5 +1,5 @@
 import { Link, useLocation } from "wouter";
-import { Home, ShoppingBag, ShoppingCart, User, ListOrdered } from "lucide-react";
+import { Home, ShoppingBag, ShoppingCart, User, ListOrdered, MessageCircle } from "lucide-react";
 import { useCart } from "@/hooks/use-cart";
 import { useAuth } from "@/hooks/use-auth";
 import { Badge } from "@/components/ui/badge";
@@ -61,6 +61,17 @@ export default function MobileNav() {
             >
               <ListOrdered className="h-5 w-5" />
               Orders
+            </Link>
+          </li>
+        )}
+        {user && (
+          <li className="flex-1">
+            <Link
+              href={user.role === "buyer" ? "/buyer/messages" : "/seller/messages"}
+              className={`flex flex-col items-center py-2 text-xs ${isActive(user.role === "buyer" ? "/buyer/messages" : "/seller/messages") ? "text-primary" : "text-gray-500"}`}
+            >
+              <MessageCircle className="h-5 w-5" />
+              Messages
             </Link>
           </li>
         )}

--- a/client/src/components/messages/conversation-preview.tsx
+++ b/client/src/components/messages/conversation-preview.tsx
@@ -1,0 +1,52 @@
+import { useQuery } from "@tanstack/react-query";
+import { Link } from "wouter";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { formatDistanceToNow } from "date-fns";
+import { Message, User } from "@shared/schema";
+import { getQueryFn } from "@/lib/queryClient";
+
+interface ConversationPreviewProps {
+  otherId: number;
+  selected?: boolean;
+}
+
+export default function ConversationPreview({ otherId, selected }: ConversationPreviewProps) {
+  const { data: user } = useQuery<User>({
+    queryKey: ["/api/users/" + otherId],
+  });
+  const { data: messages = [] } = useQuery<Message[]>({
+    queryKey: ["/api/conversations/" + otherId + "/messages"],
+  });
+
+  const lastMessage = messages[messages.length - 1];
+
+  return (
+    <Link
+      href={`/conversations/${otherId}`}
+      className={`flex items-center gap-3 p-3 border-b hover:bg-gray-50 ${selected ? "bg-gray-50" : ""}`}
+    >
+      <Avatar>
+        <AvatarImage src="https://github.com/shadcn.png" alt={user?.username} />
+        <AvatarFallback>
+          {user?.firstName?.charAt(0)}
+          {user?.lastName?.charAt(0)}
+        </AvatarFallback>
+      </Avatar>
+      <div className="flex-1 min-w-0">
+        <div className="flex justify-between text-sm">
+          <span className="font-medium">
+            {user ? `${user.firstName} ${user.lastName}` : `User #${otherId}`}
+          </span>
+          {lastMessage && (
+            <span className="text-gray-500 text-xs">
+              {formatDistanceToNow(new Date(lastMessage.createdAt), { addSuffix: true })}
+            </span>
+          )}
+        </div>
+        {lastMessage && (
+          <p className="text-gray-600 text-sm truncate">{lastMessage.content}</p>
+        )}
+      </div>
+    </Link>
+  );
+}

--- a/client/src/pages/buyer/messages.tsx
+++ b/client/src/pages/buyer/messages.tsx
@@ -1,10 +1,9 @@
 import { useQuery } from "@tanstack/react-query";
 import Header from "@/components/layout/header";
 import Footer from "@/components/layout/footer";
-import { Button } from "@/components/ui/button";
 import { useAuth } from "@/hooks/use-auth";
-import { Link } from "wouter";
 import { Order } from "@shared/schema";
+import ConversationPreview from "@/components/messages/conversation-preview";
 
 export default function BuyerMessagesPage() {
   const { user } = useAuth();
@@ -23,17 +22,9 @@ export default function BuyerMessagesPage() {
         {isLoading ? (
           <p>Loading...</p>
         ) : sellers.length > 0 ? (
-          <div className="space-y-4">
+          <div className="border rounded divide-y bg-white shadow">
             {sellers.map((sid) => (
-              <div
-                key={sid}
-                className="border rounded p-4 flex justify-between items-center bg-white shadow"
-              >
-                <span>Seller #{sid}</span>
-                <Link href={`/conversations/${sid}`}>
-                  <Button variant="outline" size="sm">View Messages</Button>
-                </Link>
-              </div>
+              <ConversationPreview key={sid} otherId={sid} />
             ))}
           </div>
         ) : (

--- a/client/src/pages/conversation.tsx
+++ b/client/src/pages/conversation.tsx
@@ -5,11 +5,21 @@ import { useConversation } from "@/hooks/use-messages";
 import { useAuth } from "@/hooks/use-auth";
 import { useEffect, useRef } from "react";
 import ChatMessage from "@/components/messages/chat-message";
+import { useQuery } from "@tanstack/react-query";
+import { Order } from "@shared/schema";
+import ConversationPreview from "@/components/messages/conversation-preview";
 
 export default function ConversationPage() {
   const { id } = useParams();
   const otherId = parseInt(id);
   const { user } = useAuth();
+  const { data: orders = [] } = useQuery<Order[]>({
+    queryKey: ["/api/orders"],
+    enabled: !!user,
+  });
+  const others = user?.role === "buyer"
+    ? Array.from(new Set(orders.map(o => o.sellerId)))
+    : Array.from(new Set(orders.map(o => o.buyerId)));
   const { data: messages = [], isLoading, sendMessage, markRead } = useConversation(otherId);
   const inputRef = useRef<HTMLInputElement>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
@@ -35,31 +45,38 @@ export default function ConversationPage() {
   return (
     <>
       <Header />
-      <main className="max-w-2xl mx-auto px-4 py-4 flex flex-col h-[calc(100vh-8rem)]">
-        <h1 className="text-xl font-semibold mb-2">Conversation</h1>
-        <div className="flex-1 overflow-y-auto space-y-2 bg-gray-50 border rounded p-4">
-          {isLoading ? (
-            <p>Loading...</p>
-          ) : (
-            messages.map(m => (
-              <ChatMessage key={m.id} message={m} isOwn={m.senderId === user?.id} />
-            ))
-          )}
-          <div ref={bottomRef} />
+      <main className="max-w-7xl mx-auto px-4 py-4 flex h-[calc(100vh-8rem)]">
+        <div className="hidden md:block w-64 border-r overflow-y-auto bg-white shadow-sm">
+          {others.map(id => (
+            <ConversationPreview key={id} otherId={id} selected={id === otherId} />
+          ))}
         </div>
-        <form onSubmit={handleSubmit} className="mt-2 flex gap-2">
-          <input
-            ref={inputRef}
-            className="flex-1 border rounded-full px-3 py-2"
-            placeholder="Type a message"
-          />
-          <button
-            type="submit"
-            className="bg-primary text-white px-4 rounded-full"
-          >
-            Send
-          </button>
-        </form>
+        <div className="flex-1 flex flex-col">
+          <h1 className="text-xl font-semibold mb-2">Conversation</h1>
+          <div className="flex-1 overflow-y-auto space-y-2 bg-gray-50 border rounded p-4">
+            {isLoading ? (
+              <p>Loading...</p>
+            ) : (
+              messages.map(m => (
+                <ChatMessage key={m.id} message={m} isOwn={m.senderId === user?.id} />
+              ))
+            )}
+            <div ref={bottomRef} />
+          </div>
+          <form onSubmit={handleSubmit} className="mt-2 flex gap-2">
+            <input
+              ref={inputRef}
+              className="flex-1 border rounded-full px-3 py-2"
+              placeholder="Type a message"
+            />
+            <button
+              type="submit"
+              className="bg-primary text-white px-4 rounded-full"
+            >
+              Send
+            </button>
+          </form>
+        </div>
       </main>
       <Footer />
     </>

--- a/client/src/pages/seller/messages.tsx
+++ b/client/src/pages/seller/messages.tsx
@@ -1,11 +1,10 @@
 import { useQuery } from "@tanstack/react-query";
 import Header from "@/components/layout/header";
 import Footer from "@/components/layout/footer";
-import { Button } from "@/components/ui/button";
-import { useProductQuestions, useUnreadMessages } from "@/hooks/use-messages";
+import { useProductQuestions } from "@/hooks/use-messages";
 import { useAuth } from "@/hooks/use-auth";
-import { Link } from "wouter";
 import { Order } from "@shared/schema";
+import ConversationPreview from "@/components/messages/conversation-preview";
 
 export default function SellerMessagesPage() {
   const { user } = useAuth();
@@ -42,14 +41,9 @@ export default function SellerMessagesPage() {
         <section>
           <h2 className="text-xl font-semibold mb-2">Conversations</h2>
           {buyers.length > 0 ? (
-            <div className="space-y-4">
+            <div className="border rounded divide-y bg-white shadow">
               {buyers.map((bid) => (
-                <div key={bid} className="border rounded p-4 flex justify-between items-center bg-white shadow">
-                  <span>Buyer #{bid}</span>
-                  <Link href={`/conversations/${bid}`}>
-                    <Button variant="outline" size="sm">View Messages</Button>
-                  </Link>
-                </div>
+                <ConversationPreview key={bid} otherId={bid} />
               ))}
             </div>
           ) : (

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -686,6 +686,25 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
+  app.get("/api/users/:id", isAuthenticated, async (req, res) => {
+    try {
+      const id = parseInt(req.params.id, 10);
+      if (Number.isNaN(id)) {
+        return res.status(400).json({ message: "Invalid user ID" });
+      }
+
+      const user = await storage.getUser(id);
+      if (!user) {
+        return res.status(404).json({ message: "User not found" });
+      }
+
+      const { password, ...userWithoutPassword } = user;
+      res.json(userWithoutPassword);
+    } catch (error) {
+      handleApiError(res, error);
+    }
+  });
+
   // Allow authenticated users to update their own contact info
   app.put("/api/users/me", isAuthenticated, async (req, res) => {
     try {


### PR DESCRIPTION
## Summary
- add API route to fetch arbitrary user details
- show messages icon instead of notifications in headers and mobile nav
- preview conversations with last message details
- show sidebar with recent conversations on the conversation page

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_6852d4d787b083308f9bcfee0f80c751