### PR TITLE
Fix admin views and navigation

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -61,10 +61,10 @@ function Router() {
       <ProtectedRoute path="/buyer/profile" component={BuyerProfilePage} allowedRoles={["buyer", "admin"]} />
 
       {/* Seller routes */}
-      <ProtectedRoute path="/seller/dashboard" component={SellerDashboard} allowedRoles={["seller", "admin"]} />
-      <ProtectedRoute path="/seller/products" component={SellerProducts} allowedRoles={["seller", "admin"]} />
-      <ProtectedRoute path="/seller/orders" component={SellerOrdersPage} allowedRoles={["seller", "admin"]} />
-      <ProtectedRoute path="/seller/messages" component={SellerMessagesPage} allowedRoles={["seller", "admin"]} />
+      <ProtectedRoute path="/seller/dashboard" component={SellerDashboard} allowedRoles={["seller"]} />
+      <ProtectedRoute path="/seller/products" component={SellerProducts} allowedRoles={["seller"]} />
+      <ProtectedRoute path="/seller/orders" component={SellerOrdersPage} allowedRoles={["seller"]} />
+      <ProtectedRoute path="/seller/messages" component={SellerMessagesPage} allowedRoles={["seller"]} />
 
       <ProtectedRoute path="/orders/:id/messages" component={OrderMessagesPage} allowedRoles={["buyer", "seller", "admin"]} />
       <ProtectedRoute path="/conversations/:id" component={ConversationPage} allowedRoles={["buyer", "seller", "admin"]} />

--- a/client/src/components/layout/header.tsx
+++ b/client/src/components/layout/header.tsx
@@ -69,10 +69,11 @@ export default function Header({ dashboardTabs, onProfileClick }: HeaderProps) {
                     label: "My Orders",
                     href: "/buyer/orders",
                   },
-                  {
-                    label: user?.isSeller ? "Dashboard" : "Sell with Us",
-                    href: user?.isSeller ? "/seller/dashboard" : "/seller/apply",
-                  },
+                  user?.role === "seller"
+                    ? { label: "Dashboard", href: "/seller/dashboard" }
+                    : !user || user.role === "buyer"
+                    ? { label: "Sell with Us", href: "/seller/apply" }
+                    : null,
                   { label: "About", href: "/about" },
                 ]
                   .filter(Boolean)

--- a/client/src/pages/home-page.tsx
+++ b/client/src/pages/home-page.tsx
@@ -28,9 +28,6 @@ export default function HomePage() {
     if (user.role === "buyer") {
       return <Redirect to="/buyer/home" />;
     }
-    if (user.role === "admin") {
-      return <Redirect to="/admin/dashboard" />;
-    }
   }
 
   return (


### PR DESCRIPTION
## Summary
- keep admins on the home page instead of redirecting to the dashboard
- restrict seller routes to sellers only
- remove seller dashboard link from the admin navigation

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_6855a1cf75748330a3575ab7b9c5fc5f