### PR TITLE
Add agreement pages

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -33,6 +33,8 @@ import AdminApplications from "@/pages/admin/applications";
 import HelpPage from "@/pages/help-page";
 import AdminTicketsPage from "@/pages/admin/tickets";
 import AboutPage from "@/pages/about-page";
+import SellerAgreementPage from "@/pages/seller-agreement";
+import BuyerAgreementPage from "@/pages/buyer-agreement";
 import NotificationsPage from "@/pages/notifications-page";
 import NotFound from "@/pages/not-found";
 
@@ -46,6 +48,8 @@ function Router() {
       <Route path="/auth" component={AuthPage} />
       <Route path="/cart" component={CartPage} />
       <Route path="/about" component={AboutPage} />
+      <Route path="/seller-agreement" component={SellerAgreementPage} />
+      <Route path="/buyer-agreement" component={BuyerAgreementPage} />
       <Route path="/help" component={HelpPage} />
       <ProtectedRoute path="/notifications" component={NotificationsPage} allowedRoles={["buyer", "seller", "admin"]} />
       

--- a/client/src/pages/buyer-agreement.tsx
+++ b/client/src/pages/buyer-agreement.tsx
@@ -1,0 +1,27 @@
+import Header from "@/components/layout/header";
+import Footer from "@/components/layout/footer";
+
+export default function BuyerAgreementPage() {
+  return (
+    <>
+      <Header />
+      <main className="max-w-4xl mx-auto px-4 py-8">
+        <h1 className="text-3xl font-extrabold tracking-tight text-gray-900 mb-4">Buyer Agreement</h1>
+        <div className="prose prose-gray">
+          <p>
+            This Buyer Agreement describes the terms that govern purchases made through SY Closeouts.
+          </p>
+          <h2>Purchasing</h2>
+          <p>Buyers are responsible for reviewing product listings and shipping costs before placing an order.</p>
+          <h2>Payment</h2>
+          <p>All payments must be made through our checkout system. Orders are not confirmed until payment is received.</p>
+          <h2>Disputes</h2>
+          <p>If you encounter issues with a seller, contact us within 7 days so we can assist in resolving the matter.</p>
+          <h2>Prohibited Conduct</h2>
+          <p>Fraudulent chargebacks, abusive behavior and other violations of our Terms of Service may result in account suspension.</p>
+        </div>
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/client/src/pages/seller-agreement.tsx
+++ b/client/src/pages/seller-agreement.tsx
@@ -1,0 +1,30 @@
+import Header from "@/components/layout/header";
+import Footer from "@/components/layout/footer";
+
+export default function SellerAgreementPage() {
+  return (
+    <>
+      <Header />
+      <main className="max-w-4xl mx-auto px-4 py-8">
+        <h1 className="text-3xl font-extrabold tracking-tight text-gray-900 mb-4">Seller Agreement</h1>
+        <div className="prose prose-gray">
+          <p>
+            This Seller Agreement outlines the rules and responsibilities that
+            apply to all sellers using the SY Closeouts marketplace.
+          </p>
+          <h2>Eligibility</h2>
+          <p>Only registered businesses or individuals over the age of 18 may sell products on our platform.</p>
+          <h2>Listings</h2>
+          <p>All listings must accurately describe inventory and comply with applicable laws. Misleading or prohibited items may be removed without notice.</p>
+          <h2>Payments</h2>
+          <p>Payments are processed through our secure payment provider. Sellers are responsible for any applicable fees and taxes.</p>
+          <h2>Disputes</h2>
+          <p>Any disputes with buyers should be reported promptly. SY Closeouts reserves the right to mediate or suspend accounts that violate these terms.</p>
+          <h2>Termination</h2>
+          <p>We may terminate or suspend your seller account for violations of this Agreement or our Terms of Service.</p>
+        </div>
+      </main>
+      <Footer />
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- add new Seller Agreement and Buyer Agreement pages
- link these pages in the router so `/seller-agreement` and `/buyer-agreement` work

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_6855b68f4d9c8330b1de0bcc6ddd16d5