### PR TITLE
Add admin message supervision

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -32,6 +32,7 @@ import AdminUsers from "@/pages/admin/users";
 import AdminApplications from "@/pages/admin/applications";
 import HelpPage from "@/pages/help-page";
 import AdminTicketsPage from "@/pages/admin/tickets";
+import AdminMessagesPage from "@/pages/admin/messages";
 import AboutPage from "@/pages/about-page";
 import SellerAgreementPage from "@/pages/seller-agreement";
 import BuyerAgreementPage from "@/pages/buyer-agreement";
@@ -78,6 +79,7 @@ function Router() {
       <ProtectedRoute path="/admin/users" component={AdminUsers} allowedRoles={["admin"]} />
       <ProtectedRoute path="/admin/applications" component={AdminApplications} allowedRoles={["admin"]} />
       <ProtectedRoute path="/admin/featured" component={FeaturedProductsPage} allowedRoles={["admin"]} />
+      <ProtectedRoute path="/admin/messages" component={AdminMessagesPage} allowedRoles={["admin"]} />
       <ProtectedRoute path="/admin/tickets" component={AdminTicketsPage} allowedRoles={["admin"]} />
 
       {/* Fallback to 404 */}

--- a/client/src/components/layout/header.tsx
+++ b/client/src/components/layout/header.tsx
@@ -80,6 +80,10 @@ export default function Header({ dashboardTabs, onProfileClick }: HeaderProps) {
                     label: "Tickets",
                     href: "/admin/tickets",
                   },
+                  user?.role === "admin" && {
+                    label: "Messages",
+                    href: "/admin/messages",
+                  },
                   { label: "About", href: "/about" },
                 ]
                   .filter(Boolean)

--- a/client/src/hooks/use-messages.tsx
+++ b/client/src/hooks/use-messages.tsx
@@ -47,6 +47,15 @@ export function useConversation(otherId: number) {
   return { ...messagesQuery, sendMessage, markRead };
 }
 
+export function useAdminConversation(userA: number, userB: number) {
+  return useQuery<Message[]>({
+    queryKey: [
+      `/api/admin/conversations/${userA}/${userB}/messages`,
+    ],
+    enabled: !!userA && !!userB,
+  });
+}
+
 export function useUnreadMessages() {
   const { data } = useQuery<{ count: number }>({
     queryKey: ["/api/messages/unread-count"],

--- a/client/src/pages/admin/messages.tsx
+++ b/client/src/pages/admin/messages.tsx
@@ -1,0 +1,65 @@
+import { useState } from "react";
+import Header from "@/components/layout/header";
+import Footer from "@/components/layout/footer";
+import { useQuery } from "@tanstack/react-query";
+import { User } from "@shared/schema";
+import { getQueryFn } from "@/lib/queryClient";
+import ChatMessage from "@/components/messages/chat-message";
+import { useAdminConversation } from "@/hooks/use-messages";
+
+export default function AdminMessagesPage() {
+  const { data: users = [] } = useQuery<User[]>({
+    queryKey: ["/api/users"],
+    queryFn: getQueryFn({ on401: "throw" }),
+  });
+
+  const [userA, setUserA] = useState<number>();
+  const [userB, setUserB] = useState<number>();
+
+  const { data: messages = [], isLoading } = useAdminConversation(userA ?? 0, userB ?? 0);
+
+  return (
+    <>
+      <Header />
+      <main className="max-w-5xl mx-auto px-4 py-8 space-y-4">
+        <h1 className="text-2xl font-bold">Message Supervision</h1>
+        <div className="flex gap-4">
+          <select
+            className="border rounded p-2"
+            value={userA ?? ""}
+            onChange={e => setUserA(Number(e.target.value) || undefined)}
+          >
+            <option value="">Select User A</option>
+            {users.map(u => (
+              <option key={u.id} value={u.id}>
+                {u.username}
+              </option>
+            ))}
+          </select>
+          <select
+            className="border rounded p-2"
+            value={userB ?? ""}
+            onChange={e => setUserB(Number(e.target.value) || undefined)}
+          >
+            <option value="">Select User B</option>
+            {users.map(u => (
+              <option key={u.id} value={u.id}>
+                {u.username}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="space-y-2 bg-gray-50 p-4 rounded h-96 overflow-y-auto">
+          {isLoading ? (
+            <p>Loading...</p>
+          ) : (
+            messages.map(m => (
+              <ChatMessage key={m.id} message={m} isOwn={m.senderId === userA} />
+            ))
+          )}
+        </div>
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -623,6 +623,26 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
+  app.get(
+    "/api/admin/conversations/:userA/:userB/messages",
+    isAuthenticated,
+    isAdmin,
+    async (req, res) => {
+      try {
+        const userA = parseInt(req.params.userA, 10);
+        const userB = parseInt(req.params.userB, 10);
+        if (Number.isNaN(userA) || Number.isNaN(userB)) {
+          return res.status(400).json({ message: "Invalid user IDs" });
+        }
+
+        const msgs = await storage.getConversationMessages(userA, userB);
+        res.json(msgs);
+      } catch (error) {
+        handleApiError(res, error);
+      }
+    },
+  );
+
   app.post("/api/conversations/:userId/messages/read", isAuthenticated, async (req, res) => {
     try {
       const otherId = parseInt(req.params.userId, 10);


### PR DESCRIPTION
## Summary
- allow admins to fetch messages between any two users via new API endpoint
- expose `useAdminConversation` hook for the frontend
- add Admin messages page and navigation link
- update routing to include new admin page

## Testing
- `npm run check` *(fails: Cannot find type definition file)*

------
https://chatgpt.com/codex/tasks/task_e_6855babb76dc8330bf7c020c497d6ac7