### PR TITLE
Add MSRP & variation fields

### DIFF
--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -105,11 +105,13 @@ export const products = pgTable("products", {
   description: text("description").notNull(),
   category: text("category").notNull(),
   price: doublePrecision("price").notNull(),
+  retailMsrp: doublePrecision("retail_msrp"),
   totalUnits: integer("total_units").notNull(),
   availableUnits: integer("available_units").notNull(),
   minOrderQuantity: integer("min_order_quantity").notNull(),
   orderMultiple: integer("order_multiple").notNull().default(1),
   images: text("images").array().notNull(),
+  variations: jsonb("variations"),
   fobLocation: text("fob_location"),
   retailComparisonUrl: text("retail_comparison_url"),
   upc: text("upc"),
@@ -129,7 +131,9 @@ export const productsRelations = relations(products, ({ one, many }) => ({
 export const insertProductSchema = createInsertSchema(products, {
   fobLocation: z.string().optional().nullable(),
   retailComparisonUrl: z.string().optional().nullable(),
-  upc: z.string().optional().nullable()
+  upc: z.string().optional().nullable(),
+  retailMsrp: z.coerce.number().optional().nullable(),
+  variations: z.record(z.array(z.string())).optional().nullable()
 })
   .omit({
     id: true,


### PR DESCRIPTION
## Summary
- add `retailMsrp` and `variations` columns to product schema
- allow creating/updating MSRP and variations in the seller product form
- show numeric fields blank until user enters a value

## Testing
- `npm run check` *(fails: Cannot find type definitions)*
- `./test_product_creation_fixed.sh` *(fails: server not running)*

------
https://chatgpt.com/codex/tasks/task_e_6855bbe901ac8330a18808b486806150