### PR TITLE
Show MSRP and enhance variation pricing

### DIFF
--- a/client/src/pages/product-detail-page.tsx
+++ b/client/src/pages/product-detail-page.tsx
@@ -200,6 +200,9 @@ export default function ProductDetailPage() {
             </div>
 
             <div className="text-3xl font-bold mb-2">{formatCurrency(unitPrice)} <span className="text-sm font-normal text-gray-500">/unit</span></div>
+            {product.retailMsrp && (
+              <div className="text-sm text-gray-500 mb-2">Retail MSRP: {formatCurrency(product.retailMsrp)}</div>
+            )}
             <div className="text-sm text-gray-600 mb-1"><Package className="inline-block h-4 w-4 mr-1" />{product.availableUnits} units</div>
             <div className="text-sm text-gray-600 mb-1"><Layers className="inline-block h-4 w-4 mr-1" />Minimum {product.minOrderQuantity} (by {product.orderMultiple})</div>
             {product.fobLocation && (


### PR DESCRIPTION
## Summary
- display retail MSRP on product detail page
- allow empty variation prices and add quick-fill dropdown

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'vite')*

------
https://chatgpt.com/codex/tasks/task_e_6855c643aa4c8330b6e7558813e706d1