### PR TITLE
Add seller order detail page

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -23,6 +23,7 @@ import BuyerMessagesPage from "@/pages/buyer/messages";
 import SellerDashboard from "@/pages/seller/dashboard";
 import SellerProducts from "@/pages/seller/products";
 import SellerOrdersPage from "@/pages/seller/orders";
+import SellerOrderDetailPage from "@/pages/seller/order-detail";
 import SellerMessagesPage from "@/pages/seller/messages";
 import SellerApply from "@/pages/seller/apply";
 import OrderMessagesPage from "@/pages/order-messages";
@@ -72,6 +73,7 @@ function Router() {
       <ProtectedRoute path="/seller/dashboard" component={SellerDashboard} allowedRoles={["seller"]} />
       <ProtectedRoute path="/seller/products" component={SellerProducts} allowedRoles={["seller"]} />
       <ProtectedRoute path="/seller/orders" component={SellerOrdersPage} allowedRoles={["seller"]} />
+      <ProtectedRoute path="/seller/orders/:id" component={SellerOrderDetailPage} allowedRoles={["seller"]} />
       <ProtectedRoute path="/seller/messages" component={SellerMessagesPage} allowedRoles={["seller"]} />
 
       <ProtectedRoute path="/orders/:id/messages" component={OrderMessagesPage} allowedRoles={["buyer", "seller", "admin"]} />

--- a/client/src/pages/seller/dashboard.tsx
+++ b/client/src/pages/seller/dashboard.tsx
@@ -394,7 +394,9 @@ export default function SellerDashboard() {
                         </div>
                         
                         <div className="flex flex-wrap gap-2 justify-end">
-                          <Button variant="outline" size="sm">View Details</Button>
+                          <Button variant="outline" size="sm" asChild>
+                            <Link href={`/seller/orders/${order.id}`}>View Details</Link>
+                          </Button>
 
                           {order.status === "ordered" && (
                             <Button size="sm" onClick={() => handleMarkAsShipped(order.id)}>

--- a/client/src/pages/seller/order-detail.tsx
+++ b/client/src/pages/seller/order-detail.tsx
@@ -1,0 +1,136 @@
+import { Link, useParams } from "wouter";
+import { useQuery } from "@tanstack/react-query";
+import { Order, OrderItem } from "@shared/schema";
+
+interface OrderItemWithProduct extends OrderItem {
+  productTitle: string;
+  productImages: string[];
+}
+
+import Header from "@/components/layout/header";
+import Footer from "@/components/layout/footer";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { CalendarIcon, ArrowLeft } from "lucide-react";
+import OrderStatus from "@/components/buyer/order-status";
+import { formatCurrency, formatDate } from "@/lib/utils";
+
+export default function SellerOrderDetailPage() {
+  const { id } = useParams();
+  const orderId = parseInt(id);
+
+  const { data: order, isLoading } = useQuery<Order & { items: OrderItemWithProduct[] }>({
+    queryKey: ["/api/orders/" + orderId],
+    enabled: !Number.isNaN(orderId),
+  });
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center min-h-screen">Loading...</div>
+    );
+  }
+
+  if (!order) {
+    return (
+      <>
+        <Header />
+        <main className="max-w-7xl mx-auto px-4 py-8 text-center">
+          <h2 className="text-2xl font-semibold">Order Not Found</h2>
+          <Link href="/seller/orders">
+            <Button className="mt-4">
+              <ArrowLeft className="mr-2 h-4 w-4" />
+              Back to Orders
+            </Button>
+          </Link>
+        </main>
+        <Footer />
+      </>
+    );
+  }
+
+  return (
+    <>
+      <Header />
+      <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 space-y-6">
+        <div>
+          <Link href="/seller/orders">
+            <a className="text-primary hover:underline flex items-center">
+              <ArrowLeft className="h-4 w-4 mr-1" />
+              Back to Orders
+            </a>
+          </Link>
+        </div>
+
+        <h1 className="text-3xl font-extrabold tracking-tight text-gray-900">
+          Order #{order.id}
+        </h1>
+        <p className="text-sm text-gray-500 flex items-center">
+          <CalendarIcon className="h-3 w-3 mr-1" /> Placed on {formatDate(order.createdAt)}
+        </p>
+        <p className="text-sm text-gray-500">Buyer #{order.buyerId}</p>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Order Summary</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-6">
+            <OrderStatus order={order} />
+
+            <div>
+              <h3 className="font-medium mb-2">Items</h3>
+              <ul className="space-y-2">
+                {order.items.map((item) => (
+                  <li key={item.id} className="flex justify-between items-center">
+                    <div className="flex items-center gap-2">
+                      <img
+                        src={item.productImages[0]}
+                        alt={item.productTitle}
+                        className="h-10 w-10 object-cover rounded"
+                      />
+                      <span>
+                        {item.quantity} x {item.productTitle}
+                      </span>
+                      {item.selectedVariations && (
+                        <span className="text-xs text-gray-500 ml-2">
+                          {Object.entries(item.selectedVariations)
+                            .map(([k, v]) => `${k}: ${v}`)
+                            .join(', ')}
+                        </span>
+                      )}
+                    </div>
+                    <span>{formatCurrency(item.totalPrice)}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+
+            <div className="border-t pt-4 flex justify-between font-medium">
+              <span>Total</span>
+              <span>{formatCurrency(order.totalAmount)}</span>
+            </div>
+          </CardContent>
+        </Card>
+
+        {order.shippingDetails && (
+          <Card>
+            <CardHeader>
+              <CardTitle>Shipping Information</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p>{order.shippingDetails.name}</p>
+              <p>{order.shippingDetails.address}</p>
+              <p>
+                {order.shippingDetails.city}, {order.shippingDetails.state}{" "}
+                {order.shippingDetails.zipCode}
+              </p>
+              <p>{order.shippingDetails.country}</p>
+              {order.shippingDetails.phone && <p>{order.shippingDetails.phone}</p>}
+              {order.shippingDetails.email && <p>{order.shippingDetails.email}</p>}
+            </CardContent>
+          </Card>
+        )}
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/client/src/pages/seller/orders.tsx
+++ b/client/src/pages/seller/orders.tsx
@@ -191,7 +191,9 @@ export default function SellerOrdersPage() {
                     </div>
 
                     <div className="flex flex-wrap gap-2 justify-end">
-                      <Button variant="outline" size="sm">View Details</Button>
+                      <Button variant="outline" size="sm" asChild>
+                        <Link href={`/seller/orders/${order.id}`}>View Details</Link>
+                      </Button>
                       <Button variant="outline" size="sm" onClick={() => handleCancelOrder(order.id)}>
                         Cancel Order
                       </Button>


### PR DESCRIPTION
## Summary
- allow sellers to navigate to order detail pages
- show ordered items and shipping information

## Testing
- `npm run check` *(fails: Cannot find type definition file for 'vite')*

------
https://chatgpt.com/codex/tasks/task_e_6855c81908788330957062ac447c7f92