### PR TITLE
Add shipping label support

### DIFF
--- a/client/src/components/buyer/order-status.tsx
+++ b/client/src/components/buyer/order-status.tsx
@@ -18,6 +18,7 @@ export default function OrderStatus({ order }: OrderStatusProps) {
   
   const statuses = [
     { name: "Ordered", icon: Calendar, color: "bg-primary", date: order.createdAt },
+    { name: "Label Generated", icon: Package, color: "bg-yellow-500", date: order.status !== "ordered" ? new Date(new Date(order.createdAt).getTime() + 1 * 24 * 60 * 60 * 1000) : null },
     { name: "Shipped", icon: Package, color: "bg-blue-500", date: order.status === "shipped" || order.status === "out_for_delivery" || order.status === "delivered" ? new Date(new Date(order.createdAt).getTime() + 2 * 24 * 60 * 60 * 1000) : null },
     { name: "Out for Delivery", icon: Truck, color: "bg-purple-500", date: order.status === "out_for_delivery" || order.status === "delivered" ? new Date(new Date(order.createdAt).getTime() + 4 * 24 * 60 * 60 * 1000) : null },
     { name: "Delivered", icon: Home, color: "bg-green-500", date: order.status === "delivered" ? new Date(new Date(order.createdAt).getTime() + 6 * 24 * 60 * 60 * 1000) : null },
@@ -26,10 +27,11 @@ export default function OrderStatus({ order }: OrderStatusProps) {
   useEffect(() => {
     // Map order status to index
     const statusMap: Record<string, number> = {
-      "ordered": 0,
-      "shipped": 1,
-      "out_for_delivery": 2,
-      "delivered": 3
+      ordered: 0,
+      label_generated: 1,
+      shipped: 2,
+      out_for_delivery: 3,
+      delivered: 4,
     };
     
     setCurrentStatus(statusMap[order.status] || 0);

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1108,6 +1108,201 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
+  // Shipping label routes
+  app.post(
+    "/api/orders/:id/shipping/rates",
+    isAuthenticated,
+    isSeller,
+    async (req, res) => {
+      try {
+        const id = parseInt(req.params.id, 10);
+        if (Number.isNaN(id)) {
+          return res.status(400).json({ message: "Invalid order ID" });
+        }
+        const user = req.user as Express.User;
+        const order = await storage.getOrder(id);
+        if (!order) return res.status(404).json({ message: "Order not found" });
+        if (order.sellerId !== user.id && user.role !== "admin") {
+          return res.status(403).json({ message: "Forbidden" });
+        }
+
+        if (!process.env.SHIPPO_API_TOKEN) {
+          return res.status(500).json({ message: "Shippo not configured" });
+        }
+
+        const buyerAddr = order.shippingDetails as any;
+        if (!buyerAddr) {
+          return res.status(400).json({ message: "Missing shipping address" });
+        }
+
+        const sellerAddresses = await storage.getAddresses(user.id);
+        const from = sellerAddresses[0];
+        if (!from) {
+          return res
+            .status(400)
+            .json({ message: "Seller has no return address" });
+        }
+
+        const { weight, length, width, height, service } = req.body;
+
+        const shipmentRes = await fetch("https://api.goshippo.com/shipments/", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `ShippoToken ${process.env.SHIPPO_API_TOKEN}`,
+          },
+          body: JSON.stringify({
+            address_from: {
+              name: from.name,
+              street1: from.address,
+              city: from.city,
+              state: from.state,
+              zip: from.zipCode,
+              country: from.country ?? "US",
+            },
+            address_to: {
+              name: buyerAddr.name,
+              street1: buyerAddr.address,
+              city: buyerAddr.city,
+              state: buyerAddr.state,
+              zip: buyerAddr.zipCode,
+              country: buyerAddr.country ?? "US",
+            },
+            parcels: [
+              {
+                length,
+                width,
+                height,
+                distance_unit: "in",
+                weight,
+                mass_unit: "oz",
+              },
+            ],
+            async: false,
+          }),
+        });
+
+        if (!shipmentRes.ok) {
+          console.error(await shipmentRes.text());
+          return res.status(500).json({ message: "Failed to fetch rates" });
+        }
+
+        const shipmentData = await shipmentRes.json();
+        let rates: any[] = shipmentData.rates || [];
+        if (service) {
+          const svc = String(service).toLowerCase();
+          rates = rates.filter(
+            (r: any) =>
+              r.provider.toLowerCase().includes(svc) ||
+              r.servicelevel?.name?.toLowerCase().includes(svc),
+          );
+        }
+
+        const markup = parseFloat(process.env.SHIPPING_MARKUP || "0.5");
+        const mapped = rates.map((r: any) => ({
+          object_id: r.object_id,
+          provider: r.provider,
+          servicelevel: r.servicelevel?.name,
+          amount: parseFloat(r.amount) + markup,
+          currency: r.currency,
+        }));
+
+        res.json({ rates: mapped });
+      } catch (error) {
+        handleApiError(res, error);
+      }
+    },
+  );
+
+  app.post(
+    "/api/orders/:id/shipping/purchase",
+    isAuthenticated,
+    isSeller,
+    async (req, res) => {
+      try {
+        const id = parseInt(req.params.id, 10);
+        if (Number.isNaN(id)) {
+          return res.status(400).json({ message: "Invalid order ID" });
+        }
+        const user = req.user as Express.User;
+        const order = await storage.getOrder(id);
+        if (!order) return res.status(404).json({ message: "Order not found" });
+        if (order.sellerId !== user.id && user.role !== "admin") {
+          return res.status(403).json({ message: "Forbidden" });
+        }
+        if (!process.env.SHIPPO_API_TOKEN) {
+          return res.status(500).json({ message: "Shippo not configured" });
+        }
+
+        const { rateObjectId } = req.body;
+        if (!rateObjectId) {
+          return res.status(400).json({ message: "Missing rateObjectId" });
+        }
+
+        const rateRes = await fetch(
+          `https://api.goshippo.com/rates/${rateObjectId}`,
+          {
+            headers: {
+              Authorization: `ShippoToken ${process.env.SHIPPO_API_TOKEN}`,
+            },
+          },
+        );
+        const rateData = await rateRes.json();
+
+        const markup = parseFloat(process.env.SHIPPING_MARKUP || "0.5");
+        const totalAmount = parseFloat(rateData.amount) + markup;
+
+        if (process.env.STRIPE_SECRET_KEY && req.body.source) {
+          await fetch("https://api.stripe.com/v1/charges", {
+            method: "POST",
+            headers: {
+              Authorization: `Bearer ${process.env.STRIPE_SECRET_KEY}`,
+              "Content-Type": "application/x-www-form-urlencoded",
+            },
+            body: new URLSearchParams({
+              amount: String(Math.round(totalAmount * 100)),
+              currency: rateData.currency || "usd",
+              source: req.body.source,
+              description: `Shipping label for order ${id}`,
+            }),
+          });
+        }
+
+        const txRes = await fetch("https://api.goshippo.com/transactions/", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `ShippoToken ${process.env.SHIPPO_API_TOKEN}`,
+          },
+          body: JSON.stringify({ rate: rateObjectId, label_file_type: "PDF" }),
+        });
+
+        const txData = await txRes.json();
+        if (txData.status !== "SUCCESS") {
+          return res.status(500).json({ message: "Failed to purchase label" });
+        }
+
+        const updatedOrder = await storage.updateOrder(id, {
+          trackingNumber: txData.tracking_number,
+          status: "label_generated",
+          shippingDetails: {
+            ...(order.shippingDetails as any),
+            labelUrl: txData.label_url,
+            carrier: rateData.provider,
+          },
+        });
+
+        res.json({
+          labelUrl: txData.label_url,
+          trackingNumber: txData.tracking_number,
+          order: updatedOrder,
+        });
+      } catch (error) {
+        handleApiError(res, error);
+      }
+    },
+  );
+
   // Support ticket routes
   app.get("/api/support-tickets", isAuthenticated, async (req, res) => {
     try {


### PR DESCRIPTION
## Summary
- enable sellers to buy shipping labels
- store tracking info from Shippo
- show new status step in order timeline

## Testing
- `npm run check` *(fails: Cannot find module)*

------
https://chatgpt.com/codex/tasks/task_e_6855dd7320cc8330a4c4c305ce9e5333