### PR TITLE
Enable manual quantity input

### DIFF
--- a/client/src/components/cart/cart-item.tsx
+++ b/client/src/components/cart/cart-item.tsx
@@ -1,5 +1,7 @@
+import { useState, useEffect } from "react";
 import { CartItem as CartItemType } from "@shared/schema";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import { formatCurrency } from "@/lib/utils";
 import { Minus, Plus, Trash2 } from "lucide-react";
 import { useCart } from "@/hooks/use-cart";
@@ -10,6 +12,11 @@ interface CartItemProps {
 
 export default function CartItem({ item }: CartItemProps) {
   const { updateQuantity, removeFromCart } = useCart();
+  const [inputQty, setInputQty] = useState(item.quantity);
+
+  useEffect(() => {
+    setInputQty(item.quantity);
+  }, [item.quantity]);
 
   const handleDecrease = () => {
     if (item.quantity <= item.minOrderQuantity) {
@@ -22,6 +29,14 @@ export default function CartItem({ item }: CartItemProps) {
         item.quantity - item.orderMultiple
       );
     }
+  };
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setInputQty(parseInt(e.target.value) || 0);
+  };
+
+  const commitInput = () => {
+    updateQuantity(item.productId, item.variationKey, inputQty);
   };
 
   const handleIncrease = () => {
@@ -67,19 +82,30 @@ export default function CartItem({ item }: CartItemProps) {
         </div>
         <div className="flex-1 flex items-end justify-between text-sm">
           <div className="flex items-center">
-            <Button 
-              variant="outline" 
-              size="icon" 
+            <Button
+              variant="outline"
+              size="icon"
               className="h-7 w-7"
               onClick={handleDecrease}
               disabled={item.quantity <= item.minOrderQuantity}
             >
               <Minus className="h-3 w-3" />
             </Button>
-            <span className="text-gray-500 mx-2 min-w-[2rem] text-center">{item.quantity}</span>
-            <Button 
-              variant="outline" 
-              size="icon" 
+            <Input
+              type="number"
+              className="mx-2 h-7 w-16 text-center"
+              value={inputQty}
+              min={item.minOrderQuantity}
+              max={item.availableUnits}
+              step={item.orderMultiple}
+              onChange={handleInputChange}
+              onBlur={commitInput}
+              onFocus={(e) => e.target.select()}
+              onKeyDown={(e) => e.key === "Enter" && e.currentTarget.blur()}
+            />
+            <Button
+              variant="outline"
+              size="icon"
               className="h-7 w-7"
               onClick={handleIncrease}
               disabled={item.quantity + item.orderMultiple > item.availableUnits}

--- a/client/src/pages/product-detail-page.tsx
+++ b/client/src/pages/product-detail-page.tsx
@@ -30,6 +30,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
+import { Input } from "@/components/ui/input";
 import { formatCurrency, SERVICE_FEE_RATE } from "@/lib/utils";
 import { useAuth } from "@/hooks/use-auth";
 import { useCart } from "@/hooks/use-cart";
@@ -239,11 +240,32 @@ export default function ProductDetailPage() {
             )}
 
             <div className="flex items-center space-x-2 mb-4">
-              <Button variant="outline" size="icon" onClick={handleDecrease} disabled={quantity <= product.minOrderQuantity}>
+              <Button
+                variant="outline"
+                size="icon"
+                onClick={handleDecrease}
+                disabled={quantity <= product.minOrderQuantity}
+              >
                 <Minus className="h-4 w-4" />
               </Button>
-              <div className="w-10 text-center">{quantity}</div>
-              <Button variant="outline" size="icon" onClick={handleIncrease} disabled={quantity + product.orderMultiple > product.availableUnits}>
+              <Input
+                type="number"
+                className="w-20 text-center"
+                value={quantity}
+                min={product.minOrderQuantity}
+                max={product.availableUnits}
+                step={product.orderMultiple}
+                onChange={(e) => setQuantity(parseInt(e.target.value) || 0)}
+                onFocus={(e) => e.target.select()}
+              />
+              <Button
+                variant="outline"
+                size="icon"
+                onClick={handleIncrease}
+                disabled={
+                  quantity + product.orderMultiple > product.availableUnits
+                }
+              >
                 <Plus className="h-4 w-4" />
               </Button>
             </div>


### PR DESCRIPTION
## Summary
- allow typing quantity on product detail page
- enable direct quantity input for cart items

## Testing
- `npm run check` *(fails: Cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_6857951b1cf08330b996fb7ffeb253a9