### PR TITLE
Add seller warning for shipping label dimensions

### DIFF
--- a/client/src/pages/seller/orders.tsx
+++ b/client/src/pages/seller/orders.tsx
@@ -326,6 +326,9 @@ export default function SellerOrdersPage() {
                 <Input value={pkgHeight} onChange={(e) => setPkgHeight(e.target.value)} placeholder="H" />
               </div>
               <Button onClick={fetchRates} disabled={loadingRates}>Get Rates</Button>
+              <p className="text-xs text-red-600 mt-2">
+                Entering incorrect package details may result in additional fees and account suspension.
+              </p>
             </div>
           )}
         </DialogContent>


### PR DESCRIPTION
## Summary
- warn sellers that incorrect package details may cause fees and suspension

## Testing
- `npm run check` *(fails: no internet access)*

------
https://chatgpt.com/codex/tasks/task_e_6857955ece7c8330b88010d76c7c4907