### PR TITLE
Shorten toast timeout

### DIFF
--- a/client/src/hooks/use-toast.ts
+++ b/client/src/hooks/use-toast.ts
@@ -6,7 +6,8 @@ import type {
 } from "@/components/ui/toast"
 
 const TOAST_LIMIT = 1
-const TOAST_REMOVE_DELAY = 1000000
+// Automatically dismiss toasts after 3 seconds to avoid blocking UI
+const TOAST_REMOVE_DELAY = 3000
 
 type ToasterToast = ToastProps & {
   id: string


### PR DESCRIPTION
## Summary
- shorten the toast dismissal delay so cart notifications go away quickly

## Testing
- `npm run check` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68579b243644833084d13899b32dbc47