### PR TITLE
Implement early user reinstatement

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1002,6 +1002,31 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
+  app.post("/api/users/:id/reinstate", isAuthenticated, isAdmin, async (req, res) => {
+    try {
+      const id = parseInt(req.params.id, 10);
+      if (Number.isNaN(id)) {
+        return res.status(400).json({ message: "Invalid user ID" });
+      }
+
+      const user = await storage.getUser(id);
+      if (!user) {
+        return res.status(404).json({ message: "User not found" });
+      }
+
+      const updated = await storage.updateUser(id, { suspendedUntil: null });
+
+      if (updated) {
+        const { password, ...u } = updated;
+        return res.json(u);
+      }
+
+      res.status(404).json({ message: "User not found" });
+    } catch (error) {
+      handleApiError(res, error);
+    }
+  });
+
   app.get("/api/users/:id", isAuthenticated, async (req, res) => {
     try {
       const id = parseInt(req.params.id, 10);


### PR DESCRIPTION
## Summary
- add API endpoint to reinstate users
- refresh admin user info after suspend/reinstate
- enhance admin Suspend Account card with label and Reinstate button

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68579be77f188330b3eea13e1ef9fba8