### PR TITLE
Shorten cart toast duration

### DIFF
--- a/client/src/hooks/use-cart.tsx
+++ b/client/src/hooks/use-cart.tsx
@@ -156,7 +156,9 @@ export function CartProvider({ children }: { children: ReactNode }) {
 
     toast({
       title: "Added to cart",
-      description: `${quantity} ${quantity === 1 ? 'unit' : 'units'} of ${product.title} added to cart.`
+      description: `${quantity} ${quantity === 1 ? 'unit' : 'units'} of ${product.title} added to cart.`,
+      // Make the cart notification disappear quickly
+      duration: 1000
     });
     
     setIsCartOpen(true);

--- a/client/src/hooks/use-toast.ts
+++ b/client/src/hooks/use-toast.ts
@@ -6,7 +6,8 @@ import type {
 } from "@/components/ui/toast"
 
 const TOAST_LIMIT = 1
-const TOAST_REMOVE_DELAY = 1000000
+// Remove closed toasts right after their closing animation finishes
+const TOAST_REMOVE_DELAY = 100
 
 type ToasterToast = ToastProps & {
   id: string


### PR DESCRIPTION
## Summary
- remove closed toasts almost immediately
- keep cart toast visible for only one second

## Testing
- `npm run check` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68579b243644833084d13899b32dbc47