### PR TITLE
Improve cart item variation styling

### DIFF
--- a/client/src/components/cart/cart-item.tsx
+++ b/client/src/components/cart/cart-item.tsx
@@ -61,18 +61,18 @@ export default function CartItem({ item }: CartItemProps) {
 
       <div className="ml-4 flex-1 flex flex-col">
         <div>
-          <div className="flex justify-between text-base font-medium text-gray-900">
-          <h3>
-            {item.title}
-          </h3>
-          {item.selectedVariations && (
-            <p className="text-xs text-gray-500">
-              {Object.entries(item.selectedVariations)
-                .map(([k, v]) => `${k}: ${v}`)
-                .join(", ")}
-            </p>
-          )}
-            <p className="ml-4">
+          <div className="flex justify-between">
+            <div>
+              <h3 className="text-base font-medium text-gray-900">{item.title}</h3>
+              {item.selectedVariations && (
+                <p className="text-xs text-gray-500">
+                  {Object.entries(item.selectedVariations)
+                    .map(([k, v]) => `${k}: ${v}`)
+                    .join(", ")}
+                </p>
+              )}
+            </div>
+            <p className="text-base font-medium text-gray-900">
               {formatCurrency(itemTotal)}
             </p>
           </div>


### PR DESCRIPTION
## Summary
- refactor CartItem layout for cleaner variant display

## Testing
- `npm run check` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_68579ed4c36083308519217e03e7407e