### PR TITLE
Unify product questions with conversations

### DIFF
--- a/client/src/pages/buyer/orders.tsx
+++ b/client/src/pages/buyer/orders.tsx
@@ -163,9 +163,6 @@ export default function BuyerOrdersPage() {
                           Download Invoice
                         </a>
                       </Button>
-                      <Button variant="outline" size="sm" asChild>
-                        <Link href={`/conversations/${order.sellerId}`}>Message Seller</Link>
-                      </Button>
                     </div>
                   </div>
                 ))}

--- a/client/src/pages/product-detail-page.tsx
+++ b/client/src/pages/product-detail-page.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { useParams, Link } from "wouter";
+import { useParams, Link, useLocation } from "wouter";
 import { useQuery, useMutation } from "@tanstack/react-query";
 import { Product } from "@shared/schema";
 import {
@@ -41,6 +41,7 @@ import Footer from "@/components/layout/footer";
 
 export default function ProductDetailPage() {
   const { id } = useParams();
+  const [, navigate] = useLocation();
   const productId = parseInt(id);
   const [quantity, setQuantity] = useState(0);
   const [selectedVariations, setSelectedVariations] = useState<Record<string, string>>({});
@@ -51,7 +52,10 @@ export default function ProductDetailPage() {
   const questionMutation = useMutation({
     mutationFn: (q: string) =>
       apiRequest("POST", `/api/products/${productId}/questions`, { question: q }),
-    onSuccess: () => toast({ title: "Question sent" }),
+    onSuccess: () => {
+      toast({ title: "Question sent" });
+      if (product) navigate(`/conversations/${product.sellerId}`);
+    },
     onError: (err: Error) =>
       toast({ title: "Failed to send question", description: err.message, variant: "destructive" }),
   });

--- a/client/src/pages/seller/dashboard.tsx
+++ b/client/src/pages/seller/dashboard.tsx
@@ -415,9 +415,6 @@ export default function SellerDashboard() {
                           <Button variant="outline" size="sm" onClick={() => handleContactBuyer(order.buyerId)}>
                             Contact Buyer
                           </Button>
-                          <Button variant="outline" size="sm" asChild>
-                            <Link href={`/conversations/${order.buyerId}`}>Messages</Link>
-                          </Button>
                         </div>
                       </div>
                     ))}

--- a/client/src/pages/seller/messages.tsx
+++ b/client/src/pages/seller/messages.tsx
@@ -1,14 +1,12 @@
 import { useQuery } from "@tanstack/react-query";
 import Header from "@/components/layout/header";
 import Footer from "@/components/layout/footer";
-import { useProductQuestions } from "@/hooks/use-messages";
 import { useAuth } from "@/hooks/use-auth";
 import { Order } from "@shared/schema";
 import ConversationPreview from "@/components/messages/conversation-preview";
 
 export default function SellerMessagesPage() {
   const { user } = useAuth();
-  const { data: questions = [], isLoading: qLoading } = useProductQuestions();
   const { data: orders = [] } = useQuery<Order[]>({
     queryKey: ["/api/orders"],
     enabled: !!user,
@@ -20,24 +18,6 @@ export default function SellerMessagesPage() {
       <Header />
       <main className="max-w-7xl mx-auto px-4 py-8 space-y-8">
         <h1 className="text-3xl font-bold">Messages</h1>
-        <section>
-          <h2 className="text-xl font-semibold mb-2">Product Questions</h2>
-          {qLoading ? (
-            <p>Loading...</p>
-          ) : questions.length > 0 ? (
-            <div className="space-y-4">
-              {questions.map((q) => (
-                <div key={q.id} className="border rounded p-4 bg-white shadow">
-                  <p className="font-medium">Product #{q.productId}</p>
-                  <p className="text-gray-700 mb-1">{q.question}</p>
-                  <p className="text-xs text-gray-500">Buyer #{q.buyerId}</p>
-                </div>
-              ))}
-            </div>
-          ) : (
-            <p>No questions yet.</p>
-          )}
-        </section>
         <section>
           <h2 className="text-xl font-semibold mb-2">Conversations</h2>
           {buyers.length > 0 ? (

--- a/client/src/pages/seller/orders.tsx
+++ b/client/src/pages/seller/orders.tsx
@@ -263,9 +263,6 @@ export default function SellerOrdersPage() {
                       <Button variant="outline" size="sm" onClick={() => handleContactBuyer(order.buyerId)}>
                         Contact Buyer
                       </Button>
-                      <Button variant="outline" size="sm" asChild>
-                        <Link href={`/conversations/${order.buyerId}`}>Messages</Link>
-                      </Button>
                     </div>
                   </div>
                 ))}


### PR DESCRIPTION
## Summary
- convert product question endpoint to create a conversation message
- open conversation after asking a product question
- remove message buttons from order views
- simplify seller messages page

## Testing
- `npm run check` *(fails: Cannot find module '@vitejs/plugin-react' and other type errors)*

------
https://chatgpt.com/codex/tasks/task_e_6857a352e4048330ae281a8eaedba070