### PR TITLE
Implement mobile scroll-to-top for product view

### DIFF
--- a/client/src/pages/product-detail-page.tsx
+++ b/client/src/pages/product-detail-page.tsx
@@ -49,6 +49,13 @@ export default function ProductDetailPage() {
   const { user } = useAuth();
   const { toast } = useToast();
 
+  // Scroll to top on mount so mobile users see the product images first
+  useEffect(() => {
+    if (typeof window !== "undefined" && window.innerWidth <= 768) {
+      window.scrollTo({ top: 0 });
+    }
+  }, []);
+
   const questionMutation = useMutation({
     mutationFn: (q: string) =>
       apiRequest("POST", `/api/products/${productId}/questions`, { question: q }),


### PR DESCRIPTION
## Summary
- ensure mobile users see product images when opening a listing by scrolling to top on mount

## Testing
- `npm run check` *(fails: Cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_685c3a35d2b88330a68398bba3bc69ba