### PR TITLE
Use dialog for product questions

### DIFF
--- a/client/src/components/products/ask-question-dialog.tsx
+++ b/client/src/components/products/ask-question-dialog.tsx
@@ -1,0 +1,57 @@
+import { useState } from "react";
+import {
+  Dialog,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+  DialogClose,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+
+interface AskQuestionDialogProps {
+  onSubmit: (question: string) => void;
+}
+
+export default function AskQuestionDialog({ onSubmit }: AskQuestionDialogProps) {
+  const [open, setOpen] = useState(false);
+  const [question, setQuestion] = useState("");
+
+  function handleSubmit() {
+    if (!question.trim()) return;
+    onSubmit(question.trim());
+    setQuestion("");
+    setOpen(false);
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button variant="outline" className="w-full mb-4">
+          Ask Seller a Question
+        </Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-[425px]">
+        <DialogHeader>
+          <DialogTitle>Ask Seller a Question</DialogTitle>
+        </DialogHeader>
+        <Textarea
+          value={question}
+          onChange={e => setQuestion(e.target.value)}
+          placeholder="Enter your question"
+          className="mt-2"
+        />
+        <DialogFooter>
+          <DialogClose asChild>
+            <Button variant="outline">Cancel</Button>
+          </DialogClose>
+          <Button onClick={handleSubmit} disabled={!question.trim()}>
+            Send
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/src/pages/product-detail-page.tsx
+++ b/client/src/pages/product-detail-page.tsx
@@ -38,6 +38,7 @@ import { apiRequest } from "@/lib/queryClient";
 import { useToast } from "@/hooks/use-toast";
 import Header from "@/components/layout/header";
 import Footer from "@/components/layout/footer";
+import AskQuestionDialog from "@/components/products/ask-question-dialog";
 
 export default function ProductDetailPage() {
   const { id } = useParams();
@@ -104,11 +105,6 @@ export default function ProductDetailPage() {
     }
   };
 
-  function handleAskQuestion() {
-    const q = window.prompt("Enter your question for the seller");
-    if (!q) return;
-    questionMutation.mutate(q);
-  }
 
   const varKey = JSON.stringify(selectedVariations);
   const basePrice =
@@ -287,9 +283,7 @@ export default function ProductDetailPage() {
               Add to Cart
             </Button>
             {user?.role === "buyer" && (
-              <Button variant="outline" className="w-full mb-4" onClick={handleAskQuestion}>
-                Ask Seller a Question
-              </Button>
+              <AskQuestionDialog onSubmit={q => questionMutation.mutate(q)} />
             )}
 
             {product.retailComparisonUrl && (


### PR DESCRIPTION
## Summary
- add AskQuestionDialog component for buyer questions
- update product detail page to use the dialog instead of a browser prompt

## Testing
- `npm run check` *(fails: Cannot find module and implicit 'any' errors)*

------
https://chatgpt.com/codex/tasks/task_e_685c3d9c3b40833088fd25339a16faee