### PR TITLE
Fix misaligned Add to Cart button text

### DIFF
--- a/client/src/pages/product-detail-page.tsx
+++ b/client/src/pages/product-detail-page.tsx
@@ -279,7 +279,7 @@ export default function ProductDetailPage() {
 
             <div className="hidden md:block text-xl font-bold mb-2">Total: {formatCurrency(totalCost)}</div>
             <Button className="hidden md:block w-full mb-4" onClick={handleAddToCart} disabled={quantity < product.minOrderQuantity}>
-              <ShoppingCart className="mr-2 h-5 w-5" />
+              <ShoppingCart className="h-4 w-4" />
               Add to Cart
             </Button>
             {user?.role === "buyer" && (
@@ -372,7 +372,7 @@ export default function ProductDetailPage() {
               disabled={quantity < product.minOrderQuantity}
               className="w-full"
             >
-              <ShoppingCart className="mr-2 h-5 w-5" />
+              <ShoppingCart className="h-4 w-4" />
               Add to Cart
             </Button>
           </div>


### PR DESCRIPTION
## Summary
- keep "Add to Cart" button content centered by removing extra margin
- use consistent icon size in the product details page

## Testing
- `npm run check` *(fails: Cannot find module 'wouter' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_685c3f1bf6808330818556cf2c2de8e8