### PR TITLE
Fix misaligned Add to Cart button text

### DIFF
--- a/client/src/pages/product-detail-page.tsx
+++ b/client/src/pages/product-detail-page.tsx
@@ -278,8 +278,12 @@ export default function ProductDetailPage() {
             </div>
 
             <div className="hidden md:block text-xl font-bold mb-2">Total: {formatCurrency(totalCost)}</div>
-            <Button className="hidden md:block w-full mb-4" onClick={handleAddToCart} disabled={quantity < product.minOrderQuantity}>
-              <ShoppingCart className="mr-2 h-5 w-5" />
+            <Button
+              className="relative hidden md:block w-full mb-4 pl-8 gap-0"
+              onClick={handleAddToCart}
+              disabled={quantity < product.minOrderQuantity}
+            >
+              <ShoppingCart className="absolute left-3 h-4 w-4" aria-hidden="true" />
               Add to Cart
             </Button>
             {user?.role === "buyer" && (
@@ -370,9 +374,9 @@ export default function ProductDetailPage() {
               size="lg"
               onClick={handleAddToCart}
               disabled={quantity < product.minOrderQuantity}
-              className="w-full"
+              className="relative w-full pl-8 gap-0"
             >
-              <ShoppingCart className="mr-2 h-5 w-5" />
+              <ShoppingCart className="absolute left-3 h-4 w-4" aria-hidden="true" />
               Add to Cart
             </Button>
           </div>


### PR DESCRIPTION
## Summary
- keep the Add to Cart text centered by placing the icon absolutely

## Testing
- `npm run check` *(fails: Cannot find module '@vitejs/plugin-react' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_685c3f1bf6808330818556cf2c2de8e8