### PR TITLE
Fix product detail scroll position

### DIFF
--- a/client/src/pages/product-detail-page.tsx
+++ b/client/src/pages/product-detail-page.tsx
@@ -51,7 +51,7 @@ export default function ProductDetailPage() {
   const { toast } = useToast();
 
   useEffect(() => {
-    if (typeof window !== "undefined" && window.innerWidth <= 768) {
+    if (typeof window !== "undefined") {
       window.scrollTo({ top: 0 });
     }
   }, []);


### PR DESCRIPTION
## Summary
- always scroll to the top when opening a product detail

## Testing
- `npm run check` *(fails: npm cannot access registry)*

------
https://chatgpt.com/codex/tasks/task_e_685c481f9504833080fbfa98950d0860