### PR TITLE
Implement scroll to top when routing

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -6,6 +6,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { AuthProvider } from "@/hooks/use-auth";
 import { CartProvider } from "@/hooks/use-cart";
 import { ProtectedRoute } from "./lib/protected-route";
+import { ScrollToTop } from "@/lib/scroll-to-top";
 
 // Pages
 import HomePage from "@/pages/home-page";
@@ -104,6 +105,7 @@ function App() {
       <AuthProvider>
         <CartProvider>
           <TooltipProvider>
+            <ScrollToTop />
             <Toaster />
             <Router />
           </TooltipProvider>

--- a/client/src/lib/scroll-to-top.tsx
+++ b/client/src/lib/scroll-to-top.tsx
@@ -1,0 +1,13 @@
+import { useEffect } from "react";
+import { useLocation } from "wouter";
+
+export function ScrollToTop() {
+  const [location] = useLocation();
+
+  useEffect(() => {
+    window.scrollTo({ top: 0, left: 0 });
+  }, [location]);
+
+  return null;
+}
+


### PR DESCRIPTION
## Summary
- add a `ScrollToTop` component that scrolls the window on location change
- render `ScrollToTop` in `App` so every navigation resets scroll position

## Testing
- `npm run check` *(fails: Cannot find module 'wouter' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_685c48d77b488330aa3c9902be96c274