### PR TITLE
Add mobile layouts for seller pages

### DIFF
--- a/client/src/pages/seller/dashboard.tsx
+++ b/client/src/pages/seller/dashboard.tsx
@@ -181,7 +181,7 @@ export default function SellerDashboard() {
               Welcome back, {user?.firstName}
             </p>
           </div>
-          <div className="flex items-center space-x-4">
+          <div className="grid grid-cols-2 sm:flex sm:space-x-4 gap-2">
             <Link href="/seller/products">
               <Button variant="outline" className="flex items-center">
                 <Package className="mr-2 h-4 w-4" />
@@ -278,7 +278,7 @@ export default function SellerDashboard() {
                   </div>
                 ) : sellerProducts.length > 0 ? (
                   <div className="space-y-4">
-                    <div className="overflow-x-auto">
+                    <div className="hidden md:block overflow-x-auto">
                       <table className="w-full text-sm">
                         <thead>
                           <tr className="border-b">
@@ -321,7 +321,35 @@ export default function SellerDashboard() {
                         </tbody>
                       </table>
                     </div>
-                    
+
+                    <div className="space-y-4 md:hidden">
+                      {sellerProducts.slice(0, 5).map((product) => (
+                        <div key={product.id} className="border rounded-md p-4 flex justify-between items-center">
+                          <div className="flex items-center gap-3">
+                            <img
+                              src={product.images[0]}
+                              alt={product.title}
+                              className="h-10 w-10 rounded object-cover"
+                            />
+                            <div>
+                              <p className="font-medium truncate w-36">{product.title}</p>
+                              <p className="text-xs text-gray-500">{formatCurrency(product.price)}</p>
+                            </div>
+                          </div>
+                          <div className="text-right text-sm space-y-1">
+                            <p>
+                              {product.availableUnits} / {product.totalUnits}
+                            </p>
+                            {product.availableUnits > 0 ? (
+                              <span className="px-2 py-1 rounded-full text-xs bg-green-100 text-green-800">In Stock</span>
+                            ) : (
+                              <span className="px-2 py-1 rounded-full text-xs bg-red-100 text-red-800">Out of Stock</span>
+                            )}
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+
                     <div className="flex justify-center">
                       <Link href="/seller/products">
                         <Button variant="outline">View All Products</Button>

--- a/client/src/pages/seller/products.tsx
+++ b/client/src/pages/seller/products.tsx
@@ -173,11 +173,11 @@ export default function SellerProducts() {
           </Link>
         </div>
         
-        <div className="flex items-center justify-between mb-6">
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between mb-6 gap-4">
           <h1 className="text-3xl font-extrabold tracking-tight text-gray-900">
             My Products
           </h1>
-          <div className="flex space-x-2">
+          <div className="flex flex-wrap gap-2">
             <BulkUpload />
             <Button
               onClick={() => setShowNewProductForm(true)}
@@ -287,8 +287,9 @@ export default function SellerProducts() {
                 <Loader2 className="h-8 w-8 animate-spin text-primary" />
               </div>
             ) : filteredProducts.length > 0 ? (
-              <div className="overflow-x-auto">
-                <Table>
+              <div>
+                <div className="hidden md:block overflow-x-auto">
+                  <Table>
                   <TableHeader>
                     <TableRow>
                       <TableHead>Product</TableHead>
@@ -364,7 +365,61 @@ export default function SellerProducts() {
                       </TableRow>
                     ))}
                   </TableBody>
-                </Table>
+                  </Table>
+                </div>
+
+                <div className="space-y-4 md:hidden">
+                  {filteredProducts.map((product) => (
+                    <div key={product.id} className="border rounded-lg p-4 space-y-2">
+                      <div className="flex items-center gap-3">
+                        <img
+                          src={product.images[0]}
+                          alt={product.title}
+                          className="h-12 w-12 rounded object-cover"
+                        />
+                        <div>
+                          <p className="font-medium">{product.title}</p>
+                          <p className="text-xs text-gray-500">{product.category}</p>
+                        </div>
+                      </div>
+                      <div className="text-sm flex justify-between">
+                        <span>{formatCurrency(product.price)}</span>
+                        <span>{product.availableUnits} / {product.totalUnits}</span>
+                      </div>
+                      <div className="flex justify-end gap-2">
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          onClick={() => handleEditProduct(product)}
+                          className="h-8 w-8 p-0"
+                        >
+                          <Edit className="h-4 w-4" />
+                          <span className="sr-only">Edit</span>
+                        </Button>
+                        {user?.role === "admin" && (
+                          <Button
+                            size="sm"
+                            variant={product.isBanner ? "default" : "outline"}
+                            onClick={() => handleToggleBanner(product)}
+                            className="h-8 w-8 p-0"
+                          >
+                            <Star className="h-4 w-4" fill={product.isBanner ? "currentColor" : "none"} />
+                            <span className="sr-only">Banner</span>
+                          </Button>
+                        )}
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          onClick={() => handleDeleteProduct(product)}
+                          className="h-8 w-8 p-0 hover:bg-red-50 hover:text-red-600 hover:border-red-200"
+                        >
+                          <Trash2 className="h-4 w-4" />
+                          <span className="sr-only">Delete</span>
+                        </Button>
+                      </div>
+                    </div>
+                  ))}
+                </div>
               </div>
             ) : (
               <div className="text-center py-8">


### PR DESCRIPTION
## Summary
- make seller dashboard nav responsive
- add mobile card view for seller dashboard inventory table
- adapt seller products page header for small screens
- show product list as cards on mobile

## Testing
- `npm run check` *(fails: Cannot find module '@tanstack/react-query')*

------
https://chatgpt.com/codex/tasks/task_e_685c4d6ee3588330ae263b6c3b18ed0e