### PR TITLE
Add threaded support ticket messages

### DIFF
--- a/client/src/hooks/use-support-tickets.tsx
+++ b/client/src/hooks/use-support-tickets.tsx
@@ -1,5 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { SupportTicket } from "@shared/schema";
+import { SupportTicket, SupportTicketMessage } from "@shared/schema";
 import { apiRequest, getQueryFn } from "@/lib/queryClient";
 
 export function useSupportTickets() {
@@ -33,5 +33,25 @@ export function useUpdateTicketStatus(id: number) {
     mutationFn: (status: string) =>
       apiRequest("POST", `/api/support-tickets/${id}/status`, { status }).then(r => r.json()),
     onSuccess: () => qc.invalidateQueries({ queryKey: ["/api/support-tickets"] }),
+  });
+}
+
+export function useTicketMessages(id?: number) {
+  return useQuery<SupportTicketMessage[]>({
+    queryKey: ["/api/support-tickets/" + id + "/messages"],
+    queryFn: getQueryFn({ on401: "throw" }),
+    enabled: !!id,
+  });
+}
+
+export function useSendTicketMessage(id: number) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (message: string) =>
+      apiRequest("POST", `/api/support-tickets/${id}/messages`, { message }).then(r => r.json()),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["/api/support-tickets/" + id + "/messages"] });
+      qc.invalidateQueries({ queryKey: ["/api/support-tickets"] });
+    },
   });
 }

--- a/client/src/pages/admin/tickets.tsx
+++ b/client/src/pages/admin/tickets.tsx
@@ -1,120 +1,82 @@
-import { useState } from "react";
+import { useState, useRef, useEffect } from "react";
 import Header from "@/components/layout/header";
 import Footer from "@/components/layout/footer";
-import { useSupportTickets, useRespondTicket, useUpdateTicketStatus } from "@/hooks/use-support-tickets";
+import { useSupportTickets, useUpdateTicketStatus, useTicketMessages, useSendTicketMessage } from "@/hooks/use-support-tickets";
+import { useAuth } from "@/hooks/use-auth";
 import { useQuery } from "@tanstack/react-query";
 import { SupportTicket, User } from "@shared/schema";
 import { getQueryFn } from "@/lib/queryClient";
-import { Button } from "@/components/ui/button";
-import { Textarea } from "@/components/ui/textarea";
 import { Badge } from "@/components/ui/badge";
-import {
-  Accordion,
-  AccordionItem,
-  AccordionTrigger,
-  AccordionContent,
-} from "@/components/ui/accordion";
-
-function TicketItem({ ticket }: { ticket: SupportTicket }) {
-  const { data: user } = useQuery<User>({
-    queryKey: ["/api/users/" + ticket.userId],
-    queryFn: getQueryFn({ on401: "throw" }),
-  });
-  const respond = useRespondTicket(ticket.id);
-  const updateStatus = useUpdateTicketStatus(ticket.id);
-  const [response, setResponse] = useState("");
-
-  return (
-    <AccordionItem value={String(ticket.id)} className="border rounded">
-      <AccordionTrigger className="px-4 py-2 flex items-start justify-between">
-        <div className="text-left space-y-1">
-          <span className="font-medium">{ticket.subject}</span>
-          <span className="text-sm text-muted-foreground">
-            {user ? user.username : `User #${ticket.userId}`} - {ticket.topic}
-          </span>
-        </div>
-        <Badge variant={ticket.status === 'open' ? 'outline' : 'default'}>
-          {ticket.status}
-        </Badge>
-      </AccordionTrigger>
-      <AccordionContent>
-        <div className="space-y-4 p-4 border-t">
-          <p className="whitespace-pre-line">{ticket.message}</p>
-          {ticket.response && (
-            <div className="space-y-1">
-              <p className="whitespace-pre-line">{ticket.response}</p>
-            </div>
-          )}
-          {(ticket.status === 'open' || !ticket.response) && (
-            <div className="flex flex-col space-y-2 items-start">
-              {!ticket.response && (
-                <form
-                  onSubmit={e => {
-                    e.preventDefault();
-                    respond.mutate(response);
-                  }}
-                  className="flex w-full flex-col space-y-2"
-                >
-                  <Textarea
-                    value={response}
-                    onChange={e => setResponse(e.target.value)}
-                    placeholder="Write your response..."
-                  />
-                  <Button type="submit" disabled={respond.isPending} className="self-end">
-                    Send Response
-                  </Button>
-                </form>
-              )}
-              {ticket.status === 'open' && (
-                <Button
-                  variant="outline"
-                  onClick={() => updateStatus.mutate('closed')}
-                  disabled={updateStatus.isPending}
-                >
-                  Close Ticket
-                </Button>
-              )}
-            </div>
-          )}
-        </div>
-      </AccordionContent>
-    </AccordionItem>
-  );
-}
+import ChatMessage from "@/components/messages/chat-message";
+import { Button } from "@/components/ui/button";
 
 export default function AdminTicketsPage() {
   const { data: tickets = [] } = useSupportTickets();
+  const { user } = useAuth();
+  const [selected, setSelected] = useState<SupportTicket>();
+  const { data: messages = [] } = useTicketMessages(selected?.id);
+  const sendMsg = useSendTicketMessage(selected?.id ?? 0);
+  const updateStatus = useUpdateTicketStatus(selected?.id ?? 0);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const bottomRef = useRef<HTMLDivElement>(null);
 
-  const openTickets = tickets.filter(t => t.status === 'open');
-  const closedTickets = tickets.filter(t => t.status !== 'open');
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages]);
+
 
   return (
     <>
       <Header />
-      <main className="max-w-5xl mx-auto px-4 py-8 space-y-8">
-        <h1 className="text-3xl font-bold">Support Tickets</h1>
-
-        <section className="space-y-2">
-          <h2 className="text-xl font-semibold">Open Tickets</h2>
-          <Accordion type="multiple" className="space-y-2">
-            {openTickets.map(t => (
-              <TicketItem key={t.id} ticket={t} />
-            ))}
-            {openTickets.length === 0 && <p>No open tickets</p>}
-          </Accordion>
-        </section>
-
-        <section className="space-y-2">
-          <h2 className="text-xl font-semibold">Closed Tickets</h2>
-          <Accordion type="multiple" className="space-y-2">
-            {closedTickets.map(t => (
-              <TicketItem key={t.id} ticket={t} />
-            ))}
-            {closedTickets.length === 0 && <p>No closed tickets</p>}
-          </Accordion>
-        </section>
+      <main className="max-w-7xl mx-auto px-4 py-8 flex h-[calc(100vh-8rem)]">
+        <div className="w-72 border-r overflow-y-auto space-y-1">
+          {tickets.map(t => (
+            <TicketListItem key={t.id} ticket={t} selected={t.id === selected?.id} onSelect={() => setSelected(t)} />
+          ))}
+          {tickets.length === 0 && <p className="p-2">No tickets</p>}
+        </div>
+        <div className="flex-1 flex flex-col ml-4">
+          {selected ? (
+            <>
+              <div className="flex items-center justify-between mb-2">
+                <h2 className="text-xl font-semibold">{selected.subject}</h2>
+                <div className="flex items-center gap-2">
+                  <Badge variant={selected.status === 'open' ? 'outline' : 'default'}>{selected.status}</Badge>
+                  {selected.status === 'open' && (
+                    <Button size="sm" variant="outline" onClick={() => updateStatus.mutate('closed')} disabled={updateStatus.isPending}>Close</Button>
+                  )}
+                </div>
+              </div>
+              <div className="flex-1 overflow-y-auto space-y-2 bg-gray-50 border rounded p-4">
+                {messages.map(m => (
+                  <ChatMessage key={m.id} message={{ id: m.id, orderId: 0, senderId: m.senderId, receiverId: 0, content: m.message, isRead: true, createdAt: m.createdAt }} isOwn={m.senderId === user?.id} />
+                ))}
+                <div ref={bottomRef} />
+              </div>
+              <form onSubmit={e => { e.preventDefault(); const value = inputRef.current?.value.trim(); if (!value) return; sendMsg.mutate(value); if (inputRef.current) inputRef.current.value = ""; }} className="mt-2 flex gap-2">
+                <input ref={inputRef} className="flex-1 border rounded-full px-3 py-2" placeholder="Type a message" />
+                <button type="submit" className="bg-primary text-white px-4 rounded-full" disabled={sendMsg.isPending}>Send</button>
+              </form>
+            </>
+          ) : (
+            <p className="m-auto text-center text-gray-500">Select a ticket</p>
+          )}
+        </div>
       </main>
       <Footer />
     </>
+  );
+}
+
+function TicketListItem({ ticket, selected, onSelect }: { ticket: SupportTicket; selected: boolean; onSelect: () => void }) {
+  const { data: user } = useQuery<User>({ queryKey: ["/api/users/" + ticket.userId], queryFn: getQueryFn({ on401: "throw" }) });
+  return (
+    <button onClick={onSelect} className={`w-full text-left px-3 py-2 border-b hover:bg-gray-50 flex justify-between ${selected ? 'bg-gray-50' : ''}`}>
+      <span>
+        {ticket.subject}
+        <span className="block text-xs text-muted-foreground">{user ? user.username : `User #${ticket.userId}`}</span>
+      </span>
+      <Badge variant={ticket.status === 'open' ? 'outline' : 'default'}>{ticket.status}</Badge>
+    </button>
   );
 }

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -556,6 +556,11 @@ export class DatabaseStorage implements IStorage {
 
   async createSupportTicket(ticket: InsertSupportTicket): Promise<SupportTicket> {
     const [t] = await db.insert(supportTickets).values(ticket).returning();
+    await db.insert(supportTicketMessages).values({
+      ticketId: t.id,
+      senderId: ticket.userId,
+      message: ticket.message,
+    });
     return t;
   }
 
@@ -575,6 +580,19 @@ export class DatabaseStorage implements IStorage {
       .where(eq(supportTickets.id, id))
       .returning();
     return t;
+  }
+
+  async getSupportTicketMessages(ticketId: number): Promise<SupportTicketMessage[]> {
+    return await db
+      .select()
+      .from(supportTicketMessages)
+      .where(eq(supportTicketMessages.ticketId, ticketId))
+      .orderBy(supportTicketMessages.createdAt);
+  }
+
+  async createSupportTicketMessage(msg: InsertSupportTicketMessage): Promise<SupportTicketMessage> {
+    const [m] = await db.insert(supportTicketMessages).values(msg).returning();
+    return m;
   }
 
   // Notification methods

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -336,6 +336,25 @@ export const insertSupportTicketSchema = createInsertSchema(supportTickets)
     createdAt: true,
   });
 
+// Individual messages within a support ticket
+export const supportTicketMessages = pgTable("support_ticket_messages", {
+  id: serial("id").primaryKey(),
+  ticketId: integer("ticket_id").notNull(),
+  senderId: integer("sender_id").notNull(),
+  message: text("message").notNull(),
+  createdAt: timestamp("created_at").defaultNow(),
+});
+
+export const supportTicketMessagesRelations = relations(supportTicketMessages, ({ one }) => ({
+  ticket: one(supportTickets, { fields: [supportTicketMessages.ticketId], references: [supportTickets.id] }),
+  sender: one(users, { fields: [supportTicketMessages.senderId], references: [users.id] }),
+}));
+
+export const insertSupportTicketMessageSchema = createInsertSchema(supportTicketMessages).omit({
+  id: true,
+  createdAt: true,
+});
+
 // In-app notifications for users
 export const notifications = pgTable("notifications", {
   id: serial("id").primaryKey(),
@@ -390,6 +409,9 @@ export type InsertProductQuestion = z.infer<typeof insertProductQuestionSchema>;
 
 export type SupportTicket = typeof supportTickets.$inferSelect;
 export type InsertSupportTicket = z.infer<typeof insertSupportTicketSchema>;
+
+export type SupportTicketMessage = typeof supportTicketMessages.$inferSelect;
+export type InsertSupportTicketMessage = z.infer<typeof insertSupportTicketMessageSchema>;
 
 export type Notification = typeof notifications.$inferSelect;
 export type InsertNotification = z.infer<typeof insertNotificationSchema>;


### PR DESCRIPTION
## Summary
- redesign support ticket center with conversation threads
- allow admins and users to exchange multiple messages
- store ticket messages in new `support_ticket_messages` table
- add API endpoints and hooks for ticket conversations
- update admin and help pages with new UI for ticket chats

## Testing
- `npm run check` *(fails: Could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685c758f57cc83308407a00db4fb0278