### PR TITLE
Improve seller analytics

### DIFF
--- a/client/src/pages/seller/analytics.tsx
+++ b/client/src/pages/seller/analytics.tsx
@@ -5,11 +5,24 @@ import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/com
 import { Button } from "@/components/ui/button";
 import { useAuth } from "@/hooks/use-auth";
 import { useQuery } from "@tanstack/react-query";
+import { Order, Product } from "@shared/schema";
 import { formatCurrency, formatDate } from "@/lib/utils";
 
 interface SummaryRow {
   date: string;
   revenue: number;
+}
+
+interface BestSeller {
+  productId: number;
+  title: string;
+  unitsSold: number;
+  revenue: number;
+}
+
+interface PayoutSummary {
+  paid: number;
+  pending: number;
 }
 
 export default function SellerAnalyticsPage() {
@@ -21,11 +34,43 @@ export default function SellerAnalyticsPage() {
   const endStr = new Date().toISOString().slice(0, 10);
 
   const { data: rows = [] } = useQuery<SummaryRow[]>({
-    queryKey: ["/api/seller/sales", startStr, endStr],
+    queryKey: [`/api/seller/sales?start=${startStr}&end=${endStr}`],
+    enabled: !!user,
+  });
+
+  const { data: orders = [] } = useQuery<Order[]>({
+    queryKey: ["/api/orders"],
+    enabled: !!user,
+  });
+
+  const { data: best = [] } = useQuery<BestSeller[]>({
+    queryKey: [`/api/seller/best-sellers?start=${startStr}&end=${endStr}`],
+    enabled: !!user,
+  });
+
+  const { data: products = [] } = useQuery<Product[]>({
+    queryKey: [`/api/products?sellerId=${user?.id ?? ""}`],
+    enabled: !!user,
+  });
+
+  const { data: payout = { paid: 0, pending: 0 } } = useQuery<PayoutSummary>({
+    queryKey: [`/api/seller/payout-summary?start=${startStr}&end=${endStr}`],
     enabled: !!user,
   });
 
   const total = rows.reduce((sum, r) => sum + r.revenue, 0);
+
+  const ordersByDay = Object.entries(
+    orders.reduce<Record<string, { count: number; revenue: number }>>((acc, o) => {
+      const d = (o.createdAt as string).slice(0, 10);
+      if (!acc[d]) acc[d] = { count: 0, revenue: 0 };
+      acc[d].count++;
+      acc[d].revenue += o.totalAmount;
+      return acc;
+    }, {}),
+  )
+    .map(([date, val]) => ({ date, ...val }))
+    .sort((a, b) => a.date.localeCompare(b.date));
 
   return (
     <>
@@ -70,6 +115,94 @@ export default function SellerAnalyticsPage() {
                   <tr key={row.date} className="border-b hover:bg-gray-50">
                     <td className="py-2 px-4">{formatDate(row.date)}</td>
                     <td className="py-2 px-4 text-right">{formatCurrency(row.revenue)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Payout Summary</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            <p>Pending: {formatCurrency(payout.pending)}</p>
+            <p>Paid Out: {formatCurrency(payout.paid)}</p>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Daily Orders</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b">
+                  <th className="py-2 px-4 text-left">Date</th>
+                  <th className="py-2 px-4 text-right">Orders</th>
+                  <th className="py-2 px-4 text-right">Revenue</th>
+                </tr>
+              </thead>
+              <tbody>
+                {ordersByDay.map((r) => (
+                  <tr key={r.date} className="border-b hover:bg-gray-50">
+                    <td className="py-2 px-4">{formatDate(r.date)}</td>
+                    <td className="py-2 px-4 text-right">{r.count}</td>
+                    <td className="py-2 px-4 text-right">{formatCurrency(r.revenue)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Best Sellers</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b">
+                  <th className="py-2 px-4 text-left">Product</th>
+                  <th className="py-2 px-4 text-right">Units</th>
+                  <th className="py-2 px-4 text-right">Revenue</th>
+                </tr>
+              </thead>
+              <tbody>
+                {best.map((b) => (
+                  <tr key={b.productId} className="border-b hover:bg-gray-50">
+                    <td className="py-2 px-4">{b.title}</td>
+                    <td className="py-2 px-4 text-right">{b.unitsSold}</td>
+                    <td className="py-2 px-4 text-right">{formatCurrency(b.revenue)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Inventory</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b">
+                  <th className="py-2 px-4 text-left">Product</th>
+                  <th className="py-2 px-4 text-right">Available</th>
+                  <th className="py-2 px-4 text-right">Total</th>
+                </tr>
+              </thead>
+              <tbody>
+                {products.map((p) => (
+                  <tr key={p.id} className="border-b hover:bg-gray-50">
+                    <td className="py-2 px-4">{p.title}</td>
+                    <td className="py-2 px-4 text-right">{p.availableUnits}</td>
+                    <td className="py-2 px-4 text-right">{p.totalUnits}</td>
                   </tr>
                 ))}
               </tbody>

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -952,6 +952,38 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
+  app.get("/api/seller/best-sellers", isAuthenticated, async (req, res) => {
+    try {
+      const user = req.user as Express.User;
+      if (user.role !== "seller" && user.role !== "admin") {
+        return res.status(403).json({ message: "Forbidden" });
+      }
+      const start = req.query.start ? new Date(String(req.query.start)) : new Date(Date.now() - 30 * 86400000);
+      const end = req.query.end ? new Date(String(req.query.end)) : new Date();
+      const sellerId = user.role === "seller" ? user.id : user.id;
+      const list = await storage.getBestSellingProducts(sellerId, start, end);
+      res.json(list);
+    } catch (error) {
+      handleApiError(res, error);
+    }
+  });
+
+  app.get("/api/seller/payout-summary", isAuthenticated, async (req, res) => {
+    try {
+      const user = req.user as Express.User;
+      if (user.role !== "seller" && user.role !== "admin") {
+        return res.status(403).json({ message: "Forbidden" });
+      }
+      const start = req.query.start ? new Date(String(req.query.start)) : new Date(Date.now() - 30 * 86400000);
+      const end = req.query.end ? new Date(String(req.query.end)) : new Date();
+      const sellerId = user.role === "seller" ? user.id : user.id;
+      const summary = await storage.getPayoutSummary(sellerId, start, end);
+      res.json(summary);
+    } catch (error) {
+      handleApiError(res, error);
+    }
+  });
+
   // Seller application routes
   app.post("/api/seller-applications", isAuthenticated, async (req, res) => {
     try {

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -91,6 +91,18 @@ export interface IStorage {
   // Billing methods
   getOrdersForBilling(): Promise<any[]>;
 
+  // Analytics methods
+  getBestSellingProducts(
+    sellerId: number,
+    start: Date,
+    end: Date,
+  ): Promise<{ productId: number; title: string; unitsSold: number; revenue: number }[]>;
+  getPayoutSummary(
+    sellerId: number,
+    start: Date,
+    end: Date,
+  ): Promise<{ paid: number; pending: number }>;
+
   // Product question methods
   createProductQuestion(question: InsertProductQuestion): Promise<ProductQuestion>;
   getProductQuestionsForSeller(sellerId: number): Promise<ProductQuestion[]>;
@@ -629,6 +641,46 @@ export class DatabaseStorage implements IStorage {
       [sellerId, start, end],
     );
     return result.rows.map((r) => ({ date: r.date, revenue: Number(r.revenue) }));
+  }
+
+  async getBestSellingProducts(
+    sellerId: number,
+    start: Date,
+    end: Date,
+  ): Promise<{ productId: number; title: string; unitsSold: number; revenue: number }[]> {
+    const result = await pool.query(
+      `SELECT oi.product_id, p.title, SUM(oi.quantity) AS units_sold, SUM(oi.total_price) AS revenue
+         FROM order_items oi
+         JOIN orders o ON o.id = oi.order_id
+         JOIN products p ON p.id = oi.product_id
+        WHERE o.seller_id = $1 AND o.created_at BETWEEN $2 AND $3
+        GROUP BY oi.product_id, p.title
+        ORDER BY units_sold DESC`,
+      [sellerId, start, end],
+    );
+    return result.rows.map((r) => ({
+      productId: r.product_id,
+      title: r.title,
+      unitsSold: Number(r.units_sold),
+      revenue: Number(r.revenue),
+    }));
+  }
+
+  async getPayoutSummary(
+    sellerId: number,
+    start: Date,
+    end: Date,
+  ): Promise<{ paid: number; pending: number }> {
+    const result = await pool.query(
+      `SELECT
+          COALESCE(SUM(total_amount) FILTER (WHERE seller_paid = true), 0) AS paid,
+          COALESCE(SUM(total_amount) FILTER (WHERE seller_paid = false AND status = 'delivered'), 0) AS pending
+         FROM orders
+        WHERE seller_id = $1 AND created_at BETWEEN $2 AND $3`,
+      [sellerId, start, end],
+    );
+    const row = result.rows[0] || { paid: 0, pending: 0 };
+    return { paid: Number(row.paid), pending: Number(row.pending) };
   }
 
   async getOrdersForBilling(): Promise<any[]> {


### PR DESCRIPTION
## Summary
- implement `getBestSellingProducts` and `getPayoutSummary` in storage
- expose `/api/seller/best-sellers` and `/api/seller/payout-summary` routes
- revamp seller analytics page with sales, orders, best sellers, inventory and payout info

## Testing
- `npm run check` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685c764ce464833094332b36b443dcb5