### PR TITLE
Implement encoded order codes

### DIFF
--- a/client/src/pages/admin/dashboard.tsx
+++ b/client/src/pages/admin/dashboard.tsx
@@ -297,7 +297,7 @@ export default function AdminDashboard() {
                         {orders.slice(0, 5).map((order) => (
                           <div key={order.id} className="flex justify-between items-center border-b pb-4">
                             <div>
-                              <p className="font-medium">Order #{order.id}</p>
+                              <p className="font-medium">Order #{order.code}</p>
                               <p className="text-sm text-gray-500">
                                 Buyer #{order.buyerId} • Seller #{order.sellerId}
                               </p>

--- a/client/src/pages/admin/order-detail.tsx
+++ b/client/src/pages/admin/order-detail.tsx
@@ -62,7 +62,7 @@ export default function AdminOrderDetailPage() {
         </div>
 
         <h1 className="text-3xl font-extrabold tracking-tight text-gray-900">
-          Order #{order.id}
+          Order #{order.code}
         </h1>
         <p className="text-sm text-gray-500 flex items-center">
           <CalendarIcon className="h-3 w-3 mr-1" /> Placed on {formatDate(order.createdAt)}

--- a/client/src/pages/admin/user-profile.tsx
+++ b/client/src/pages/admin/user-profile.tsx
@@ -131,7 +131,7 @@ export default function AdminUserProfilePage() {
             <p>On-time delivery rate: {(onTimeRate * 100).toFixed(0)}%</p>
             {orders.map(o => (
               <div key={o.id} className="border rounded p-2 text-sm">
-                Order #{o.id} - {o.status}
+                Order #{o.code} - {o.status}
               </div>
             ))}
           </CardContent>

--- a/client/src/pages/buyer/order-detail.tsx
+++ b/client/src/pages/buyer/order-detail.tsx
@@ -68,7 +68,7 @@ export default function BuyerOrderDetailPage() {
         </div>
 
         <h1 className="text-3xl font-extrabold tracking-tight text-gray-900">
-          Order #{order.id}
+          Order #{order.code}
         </h1>
         <p className="text-sm text-gray-500 flex items-center">
           <CalendarIcon className="h-3 w-3 mr-1" /> Placed on {formatDate(order.createdAt)}

--- a/client/src/pages/buyer/orders.tsx
+++ b/client/src/pages/buyer/orders.tsx
@@ -53,7 +53,7 @@ export default function BuyerOrdersPage() {
     if (filter !== "all" && order.status !== filter) {
       return false;
     }
-    if (searchTerm && !order.id.toString().includes(searchTerm)) {
+    if (searchTerm && !order.code.toLowerCase().includes(searchTerm.toLowerCase())) {
       return false;
     }
     return true;
@@ -79,7 +79,7 @@ export default function BuyerOrdersPage() {
                 <div className="relative">
                   <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 h-4 w-4" />
                   <Input
-                    placeholder="Search by order #"
+                    placeholder="Search by order code"
                     className="pl-10 w-full sm:w-[200px] rounded-full"
                     value={searchTerm}
                     onChange={(e) => setSearchTerm(e.target.value)}
@@ -125,13 +125,13 @@ export default function BuyerOrdersPage() {
                         {order.previewImage && (
                           <img
                             src={order.previewImage}
-                            alt={`Order ${order.id} item`}
+                            alt={`Order ${order.code} item`}
                             className="w-20 h-20 object-cover rounded"
                           />
                         )}
                         <div className="flex flex-col sm:flex-row sm:justify-between mb-4 gap-2 flex-1">
                           <div>
-                            <h3 className="font-medium">Order #{order.id}</h3>
+                            <h3 className="font-medium">Order #{order.code}</h3>
                             <p className="text-sm text-gray-500 flex items-center">
                               <CalendarIcon className="h-3 w-3 mr-1" />
                               Placed on {formatDate(order.createdAt)}
@@ -186,13 +186,13 @@ export default function BuyerOrdersPage() {
                           {order.previewImage && (
                             <img
                               src={order.previewImage}
-                              alt={`Order ${order.id} item`}
+                          alt={`Order ${order.code} item`}
                               className="w-12 h-12 object-cover rounded"
                             />
                           )}
                           <div className="flex flex-col flex-1 gap-1">
                             <div className="flex items-center justify-between">
-                              <span className="font-medium">Order #{order.id}</span>
+                              <span className="font-medium">Order #{order.code}</span>
                               <span className={`text-xs px-2 py-1 rounded-full ${
                                 order.status === "delivered"
                                   ? "bg-green-100 text-green-800"

--- a/client/src/pages/seller/dashboard.tsx
+++ b/client/src/pages/seller/dashboard.tsx
@@ -304,7 +304,7 @@ export default function SellerDashboard() {
                       <tbody>
                         {pendingPayouts.map((order) => (
                           <tr key={order.id} className="border-b">
-                            <td className="py-2 px-4">#{order.id}</td>
+                            <td className="py-2 px-4">#{order.code}</td>
                             <td className="py-2 px-4">{order.status}</td>
                             <td className="py-2 px-4 text-right">{formatCurrency(order.totalAmount * (1 - SERVICE_FEE_RATE))}</td>
                             <td className="py-2 px-4 text-right">{formatDate(getPayoutDate(order))}</td>
@@ -461,7 +461,7 @@ export default function SellerDashboard() {
                       <div key={order.id} className="border rounded-lg p-4">
                         <div className="flex flex-col sm:flex-row sm:justify-between mb-4 gap-2">
                           <div>
-                            <h3 className="font-medium">Order #{order.id}</h3>
+                            <h3 className="font-medium">Order #{order.code}</h3>
                             <p className="text-sm text-gray-500 flex items-center">
                               <CalendarIcon className="h-3 w-3 mr-1" />
                               Placed on {formatDate(order.createdAt)}

--- a/client/src/pages/seller/order-detail.tsx
+++ b/client/src/pages/seller/order-detail.tsx
@@ -62,7 +62,7 @@ export default function SellerOrderDetailPage() {
         </div>
 
         <h1 className="text-3xl font-extrabold tracking-tight text-gray-900">
-          Order #{order.id}
+          Order #{order.code}
         </h1>
         <p className="text-sm text-gray-500 flex items-center">
           <CalendarIcon className="h-3 w-3 mr-1" /> Placed on {formatDate(order.createdAt)}

--- a/client/src/pages/seller/orders.tsx
+++ b/client/src/pages/seller/orders.tsx
@@ -197,7 +197,7 @@ export default function SellerOrdersPage() {
                   <div key={order.id} className="border rounded-lg p-4">
                     <div className="flex flex-col sm:flex-row sm:justify-between mb-4 gap-2">
                       <div>
-                        <h3 className="font-medium">Order #{order.id}</h3>
+                        <h3 className="font-medium">Order #{order.code}</h3>
                         <p className="text-sm text-gray-500 flex items-center">
                           <CalendarIcon className="h-3 w-3 mr-1" />
                           Placed on {formatDate(order.createdAt)}

--- a/server/email.ts
+++ b/server/email.ts
@@ -129,7 +129,7 @@ export async function sendInvoiceEmail(
             </tbody>
           </table>
 
-          <p style="margin-top:30px;">Invoice #: <strong>#INV-${order.id}</strong></p>
+          <p style="margin-top:30px;">Invoice #: <strong>#INV-${order.code}</strong></p>
           <p>Order Date: <strong>${new Date(order.createdAt || Date.now()).toDateString()}</strong></p>
         </td>
       </tr>
@@ -154,10 +154,10 @@ export async function sendInvoiceEmail(
   const mailOptions = {
     from: process.env.SMTP_FROM || user,
     to,
-    subject: `Invoice for Order #${order.id}`,
+    subject: `Invoice for Order #${order.code}`,
     text:
       `Thank you for your order!\n\n` +
-      `Order ID: ${order.id}\n` +
+      `Order ID: ${order.code}\n` +
       `Total: $${order.totalAmount.toFixed(2)}\n\n` +
       `Items:\n${itemLines}\n\n` +
       `We appreciate your business!`,
@@ -286,7 +286,7 @@ export async function sendSellerOrderEmail(
 
           ${shippingLines ? `<div style="margin-top:20px;"><strong>Ship To:</strong>${shippingLines}</div>` : ""}
 
-          <p style="margin-top:30px;">Order #: <strong>${order.id}</strong></p>
+          <p style="margin-top:30px;">Order #: <strong>${order.code}</strong></p>
           <p>Order Date: <strong>${new Date(order.createdAt || Date.now()).toDateString()}</strong></p>
         </td>
       </tr>
@@ -311,10 +311,10 @@ export async function sendSellerOrderEmail(
   const mailOptions = {
     from: process.env.SMTP_FROM || user,
     to,
-    subject: `New Order #${order.id} Received`,
+    subject: `New Order #${order.code} Received`,
     text:
       `You have a new order!\n\n` +
-      `Order ID: ${order.id}\n` +
+      `Order ID: ${order.code}\n` +
       `Total: $${order.totalAmount.toFixed(2)}\n\n` +
       `Items:\n${itemLines}\n`,
     html,
@@ -343,7 +343,7 @@ export async function sendShippingUpdateEmail(to: string, order: Order) {
   const mailOptions = {
     from: process.env.SMTP_FROM || user,
     to,
-    subject: `Shipping update for Order #${order.id}`,
+    subject: `Shipping update for Order #${order.code}`,
     text: `Your order status is now: ${order.status}`,
   };
 
@@ -376,7 +376,7 @@ export async function sendSellerApprovalEmail(to: string) {
 
 export async function sendOrderMessageEmail(
   to: string,
-  orderId: number,
+  orderCode: string,
   message: string,
 ) {
   if (!transporter) {
@@ -387,7 +387,7 @@ export async function sendOrderMessageEmail(
   const mailOptions = {
     from: process.env.SMTP_FROM || user,
     to,
-    subject: `Message regarding Order #${orderId}`,
+    subject: `Message regarding Order #${orderCode}`,
     text: message,
   };
 

--- a/server/orderCode.ts
+++ b/server/orderCode.ts
@@ -1,0 +1,5 @@
+export function generateOrderCode(id: number): string {
+  const multiplier = 9973; // prime number
+  const offset = 12345;
+  return 'O' + ((id * multiplier + offset).toString(36).toUpperCase());
+}

--- a/server/pdf.ts
+++ b/server/pdf.ts
@@ -20,7 +20,7 @@ function textBlock(x: number, y: number, size: number, text: string) {
 export function generateInvoicePdf(order: Order, items: InvoiceItem[]): Buffer {
   const lines: string[] = [];
   lines.push(textBlock(50, 760, 24, "INVOICE"));
-  lines.push(textBlock(50, 735, 12, `Order #: ${order.id}`));
+  lines.push(textBlock(50, 735, 12, `Order #: ${order.code}`));
   lines.push(
     textBlock(50, 720, 12, `Date: ${new Date(order.createdAt || Date.now()).toDateString()}`)
   );

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -152,6 +152,7 @@ export const insertProductSchema = createInsertSchema(products, {
 // Order schema
 export const orders = pgTable("orders", {
   id: serial("id").primaryKey(),
+  code: text("code").notNull().unique(),
   buyerId: integer("buyer_id").notNull(),
   sellerId: integer("seller_id").notNull(),
   totalAmount: doublePrecision("total_amount").notNull(),
@@ -181,6 +182,7 @@ export const ordersRelations = relations(orders, ({ one, many }) => ({
 export const insertOrderSchema = createInsertSchema(orders)
   .omit({
     id: true,
+    code: true,
     buyerCharged: true,
     sellerPaid: true,
     deliveredAt: true,


### PR DESCRIPTION
## Summary
- add `code` column to orders schema
- generate encoded order codes
- use order codes in invoices and emails
- display order codes across the frontend

## Testing
- `npm run check` *(fails: Cannot find module '@vitejs/plugin-react' and other type errors)*

------
https://chatgpt.com/codex/tasks/task_e_685c7b1296288330876009d23e60a585