### PR TITLE
Scroll to top on messages pages

### DIFF
--- a/client/src/pages/admin/messages.tsx
+++ b/client/src/pages/admin/messages.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import Header from "@/components/layout/header";
 import Footer from "@/components/layout/footer";
 import { useQuery } from "@tanstack/react-query";
@@ -23,6 +23,10 @@ export default function AdminMessagesPage() {
   );
 
   const { data: messages = [], isLoading } = useAdminUserMessages(selectedUser ?? 0);
+
+  useEffect(() => {
+    window.scrollTo({ top: 0 });
+  }, []);
 
   return (
     <>

--- a/client/src/pages/buyer/messages.tsx
+++ b/client/src/pages/buyer/messages.tsx
@@ -4,6 +4,7 @@ import Footer from "@/components/layout/footer";
 import { useAuth } from "@/hooks/use-auth";
 import { Order } from "@shared/schema";
 import ConversationPreview from "@/components/messages/conversation-preview";
+import { useEffect } from "react";
 
 export default function BuyerMessagesPage() {
   const { user } = useAuth();
@@ -11,6 +12,10 @@ export default function BuyerMessagesPage() {
     queryKey: ["/api/orders"],
     enabled: !!user,
   });
+
+  useEffect(() => {
+    window.scrollTo({ top: 0 });
+  }, []);
 
   const sellers = Array.from(new Set(orders.map(o => o.sellerId)));
 

--- a/client/src/pages/seller/messages.tsx
+++ b/client/src/pages/seller/messages.tsx
@@ -4,6 +4,7 @@ import Footer from "@/components/layout/footer";
 import { useAuth } from "@/hooks/use-auth";
 import { Order } from "@shared/schema";
 import ConversationPreview from "@/components/messages/conversation-preview";
+import { useEffect } from "react";
 
 export default function SellerMessagesPage() {
   const { user } = useAuth();
@@ -12,6 +13,10 @@ export default function SellerMessagesPage() {
     enabled: !!user,
   });
   const buyers = Array.from(new Set(orders.map(o => o.buyerId)));
+
+  useEffect(() => {
+    window.scrollTo({ top: 0 });
+  }, []);
 
   return (
     <>


### PR DESCRIPTION
## Summary
- ensure buyer messages page scrolls to top when opened
- ensure seller messages page scrolls to top when opened
- ensure admin messages page scrolls to top when opened

## Testing
- `npm run check` *(fails: Cannot find module)*

------
https://chatgpt.com/codex/tasks/task_e_685cc226f2a8833096c205ce7b7ef65f