### PR TITLE
Enable profile editing with avatar uploads

### DIFF
--- a/client/src/components/account/edit-profile-dialog.tsx
+++ b/client/src/components/account/edit-profile-dialog.tsx
@@ -1,0 +1,178 @@
+import { ReactNode } from "react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useMutation } from "@tanstack/react-query";
+import { apiRequest, queryClient } from "@/lib/queryClient";
+import { useToast } from "@/hooks/use-toast";
+import { useAuth } from "@/hooks/use-auth";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+  DialogClose,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage } from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Loader2 } from "lucide-react";
+
+const schema = z.object({
+  firstName: z.string().min(1, "First name is required"),
+  lastName: z.string().min(1, "Last name is required"),
+  company: z.string().optional(),
+  phone: z.string().optional(),
+  address: z.string().optional(),
+  avatarUrl: z.string().url("Invalid URL").optional().or(z.literal("")),
+});
+
+type FormData = z.infer<typeof schema>;
+
+export function EditProfileDialog({ children }: { children: ReactNode }) {
+  const { user } = useAuth();
+  const { toast } = useToast();
+
+  const form = useForm<FormData>({
+    resolver: zodResolver(schema),
+    defaultValues: {
+      firstName: user?.firstName || "",
+      lastName: user?.lastName || "",
+      company: user?.company || "",
+      phone: user?.phone || "",
+      address: user?.address || "",
+      avatarUrl: user?.avatarUrl || "",
+    },
+  });
+
+  const mutation = useMutation({
+    mutationFn: async (data: FormData) => {
+      const res = await apiRequest("PUT", "/api/users/me", data);
+      return res.json();
+    },
+    onSuccess: (updatedUser) => {
+      queryClient.setQueryData(["/api/user"], updatedUser);
+      toast({ title: "Profile updated" });
+    },
+    onError: (err: Error) => {
+      toast({
+        title: "Update failed",
+        description: err.message,
+        variant: "destructive",
+      });
+    },
+  });
+
+  return (
+    <Dialog>
+      <DialogTrigger asChild>{children}</DialogTrigger>
+      <DialogContent className="sm:max-w-[425px]">
+        <DialogHeader>
+          <DialogTitle>Edit Profile</DialogTitle>
+          <DialogDescription>Update your account details.</DialogDescription>
+        </DialogHeader>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit((d) => mutation.mutate(d))} className="space-y-4">
+            <FormField
+              control={form.control}
+              name="firstName"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>First Name</FormLabel>
+                  <FormControl>
+                    <Input {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="lastName"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Last Name</FormLabel>
+                  <FormControl>
+                    <Input {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="company"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Company</FormLabel>
+                  <FormControl>
+                    <Input {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="phone"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Phone</FormLabel>
+                  <FormControl>
+                    <Input {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="address"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Address</FormLabel>
+                  <FormControl>
+                    <Input {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="avatarUrl"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Profile Picture URL</FormLabel>
+                  <FormControl>
+                    <Input {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <DialogFooter>
+              <DialogClose asChild>
+                <Button variant="outline" type="button">
+                  Cancel
+                </Button>
+              </DialogClose>
+              <Button type="submit" disabled={mutation.isPending}>
+                {mutation.isPending ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" /> Saving...
+                  </>
+                ) : (
+                  "Save Changes"
+                )}
+              </Button>
+            </DialogFooter>
+          </form>
+        </Form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/client/src/components/layout/header-fixed.tsx
+++ b/client/src/components/layout/header-fixed.tsx
@@ -121,7 +121,7 @@ export default function Header() {
                   <DropdownMenuTrigger asChild>
                     <Button variant="ghost" className="relative h-8 w-8 rounded-full">
                       <Avatar className="h-8 w-8">
-                        <AvatarImage src="https://github.com/shadcn.png" alt={user.username} />
+                        <AvatarImage src={user.avatarUrl || "https://github.com/shadcn.png"} alt={user.username} />
                         <AvatarFallback>{user.firstName.charAt(0)}{user.lastName.charAt(0)}</AvatarFallback>
                       </Avatar>
                     </Button>
@@ -215,7 +215,7 @@ export default function Header() {
                 <div className="flex items-center px-4">
                   <div className="flex-shrink-0">
                     <Avatar className="h-10 w-10">
-                      <AvatarImage src="https://github.com/shadcn.png" alt={user.username} />
+                      <AvatarImage src={user.avatarUrl || "https://github.com/shadcn.png"} alt={user.username} />
                       <AvatarFallback>{user.firstName.charAt(0)}{user.lastName.charAt(0)}</AvatarFallback>
                     </Avatar>
                   </div>

--- a/client/src/components/layout/header.tsx
+++ b/client/src/components/layout/header.tsx
@@ -160,7 +160,7 @@ export default function Header({ dashboardTabs, onProfileClick }: HeaderProps) {
                   <DropdownMenuTrigger asChild>
                     <Button variant="ghost" className="relative h-8 w-8 rounded-full">
                       <Avatar className="h-8 w-8">
-                        <AvatarImage src="https://github.com/shadcn.png" alt={user.username} />
+                        <AvatarImage src={user.avatarUrl || "https://github.com/shadcn.png"} alt={user.username} />
                         <AvatarFallback>
                           {user.firstName.charAt(0)}
                           {user.lastName.charAt(0)}
@@ -258,7 +258,7 @@ export default function Header({ dashboardTabs, onProfileClick }: HeaderProps) {
                 <div className="flex items-center px-4">
                   <div className="flex-shrink-0">
                     <Avatar className="h-10 w-10">
-                      <AvatarImage src="https://github.com/shadcn.png" alt={user.username} />
+                      <AvatarImage src={user.avatarUrl || "https://github.com/shadcn.png"} alt={user.username} />
                       <AvatarFallback>
                         {user.firstName.charAt(0)}
                         {user.lastName.charAt(0)}

--- a/client/src/components/messages/conversation-preview.tsx
+++ b/client/src/components/messages/conversation-preview.tsx
@@ -26,7 +26,7 @@ export default function ConversationPreview({ otherId, selected }: ConversationP
       className={`flex items-center gap-3 p-3 border-b hover:bg-gray-50 ${selected ? "bg-gray-50" : ""}`}
     >
       <Avatar>
-        <AvatarImage src="https://github.com/shadcn.png" alt={user?.username} />
+        <AvatarImage src={user?.avatarUrl || "https://github.com/shadcn.png"} alt={user?.username} />
         <AvatarFallback>
           {user?.firstName?.charAt(0)}
           {user?.lastName?.charAt(0)}

--- a/client/src/pages/buyer/profile.tsx
+++ b/client/src/pages/buyer/profile.tsx
@@ -8,6 +8,7 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { useAuth } from "@/hooks/use-auth";
 import { ChangePasswordDialog } from "@/components/account/change-password-dialog";
+import { EditProfileDialog } from "@/components/account/edit-profile-dialog";
 import { formatDate } from "@/lib/utils";
 
 export default function BuyerProfilePage() {
@@ -36,7 +37,7 @@ export default function BuyerProfilePage() {
             <CardContent className="p-4 sm:p-6">
               <div className="flex flex-col items-center">
                 <Avatar className="h-24 w-24 mb-4">
-                  <AvatarImage src="https://github.com/shadcn.png" alt={user?.username} />
+                  <AvatarImage src={user?.avatarUrl || "https://github.com/shadcn.png"} alt={user?.username} />
                   <AvatarFallback className="text-lg">
                     {user?.firstName?.charAt(0)}{user?.lastName?.charAt(0)}
                   </AvatarFallback>
@@ -47,7 +48,9 @@ export default function BuyerProfilePage() {
                 </h3>
                 <p className="text-gray-500 mb-4">{user?.email}</p>
 
-                <Button className="w-full mb-2">Edit Profile</Button>
+                <EditProfileDialog>
+                  <Button className="w-full mb-2">Edit Profile</Button>
+                </EditProfileDialog>
                 <ChangePasswordDialog>
                   <Button variant="outline" className="w-full">Change Password</Button>
                 </ChangePasswordDialog>

--- a/client/src/pages/seller/dashboard.tsx
+++ b/client/src/pages/seller/dashboard.tsx
@@ -22,6 +22,7 @@ import { Button } from "@/components/ui/button";
 import { apiRequest } from "@/lib/queryClient";
 import { useToast } from "@/hooks/use-toast";
 import { ChangePasswordDialog } from "@/components/account/change-password-dialog";
+import { EditProfileDialog } from "@/components/account/edit-profile-dialog";
 import {
   Dialog,
   DialogContent,
@@ -602,7 +603,7 @@ export default function SellerDashboard() {
                 <CardContent>
                   <div className="flex flex-col items-center">
                     <Avatar className="h-24 w-24 mb-4">
-                      <AvatarImage src="https://github.com/shadcn.png" alt={user?.username} />
+                      <AvatarImage src={user?.avatarUrl || "https://github.com/shadcn.png"} alt={user?.username} />
                       <AvatarFallback className="text-lg">
                         {user?.firstName?.charAt(0)}{user?.lastName?.charAt(0)}
                       </AvatarFallback>
@@ -612,7 +613,9 @@ export default function SellerDashboard() {
                     <p className="text-gray-500 mb-1">{user?.email}</p>
                     <p className="text-primary font-medium mb-4">Verified Seller</p>
                     
-                    <Button className="w-full mb-2">Edit Profile</Button>
+                    <EditProfileDialog>
+                      <Button className="w-full mb-2">Edit Profile</Button>
+                    </EditProfileDialog>
                     <ChangePasswordDialog>
                       <Button variant="outline" className="w-full">Change Password</Button>
                     </ChangePasswordDialog>

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -20,6 +20,7 @@ declare global {
       company?: string | null;
       phone?: string | null;
       address?: string | null;
+      avatarUrl?: string | null;
       role: string;
       isSeller: boolean | null;
       isApproved: boolean | null;

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1114,8 +1114,11 @@ export async function registerRoutes(app: Express): Promise<Server> {
       }
 
       // Remove password from response
+      Object.assign(req.user, updatedUser);
       const { password, ...userWithoutPassword } = updatedUser;
-      res.json(userWithoutPassword);
+      req.session.save(() => {
+        res.json(userWithoutPassword);
+      });
     } catch (error) {
       handleApiError(res, error);
     }
@@ -1202,8 +1205,12 @@ export async function registerRoutes(app: Express): Promise<Server> {
     try {
       const user = req.user as Express.User;
       const updatedUser = await storage.updateUser(user.id, {
+        firstName: req.body.firstName,
+        lastName: req.body.lastName,
+        company: req.body.company,
         phone: req.body.phone,
         address: req.body.address,
+        avatarUrl: req.body.avatarUrl,
       });
 
       if (!updatedUser) {

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -14,6 +14,7 @@ export const users = pgTable("users", {
   company: text("company"),
   phone: text("phone"),
   address: text("address"),
+  avatarUrl: text("avatar_url"),
   role: text("role").notNull().default("buyer"), // buyer, seller, admin
   isSeller: boolean("is_seller").default(false),
   isApproved: boolean("is_approved").default(false),
@@ -92,6 +93,7 @@ export const insertUserSchema = createInsertSchema(users)
   .extend({
     phone: z.string().optional(),
     address: z.string().optional(),
+    avatarUrl: z.string().url().optional(),
   })
   .refine((data) => data.password.length >= 6, {
     message: "Password must be at least 6 characters long",


### PR DESCRIPTION
## Summary
- allow avatarUrl field in user schema
- expose avatarUrl in Express user type
- update `/api/users/me` to edit profile details
- add `EditProfileDialog` component for updating profile
- show uploaded avatar in headers, profile pages, and conversations

## Testing
- `npm run check` *(fails: Cannot find module '@vitejs/plugin-react' ...)*

------
https://chatgpt.com/codex/tasks/task_e_685d755743208330a77f510ad637c966