### PR TITLE
Enable profile picture uploads

### DIFF
--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -93,7 +93,7 @@ export const insertUserSchema = createInsertSchema(users)
   .extend({
     phone: z.string().optional(),
     address: z.string().optional(),
-    avatarUrl: z.string().url().optional(),
+    avatarUrl: z.string().optional(),
   })
   .refine((data) => data.password.length >= 6, {
     message: "Password must be at least 6 characters long",


### PR DESCRIPTION
## Summary
- allow image uploads in edit profile dialog
- relax avatar URL validation to permit any string

## Testing
- `npm run check` *(fails: Cannot access npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_685d95f0152c8330b698ce8f88b8ccd7