### PR TITLE
Fix order confirmation code display

### DIFF
--- a/client/src/pages/checkout-page.tsx
+++ b/client/src/pages/checkout-page.tsx
@@ -721,7 +721,7 @@ export default function CheckoutPage() {
       <div className="bg-gray-50 rounded-lg p-6 mb-6 text-left">
         <div className="flex justify-between mb-2">
           <span className="text-sm font-medium text-gray-600">Order Number:</span>
-          <span className="text-sm font-medium">{order?.id || "N/A"}</span>
+          <span className="text-sm font-medium">{order?.code || "N/A"}</span>
         </div>
         <div className="flex justify-between mb-2">
           <span className="text-sm font-medium text-gray-600">Order Date:</span>

--- a/client/src/pages/seller/dashboard.tsx
+++ b/client/src/pages/seller/dashboard.tsx
@@ -349,7 +349,7 @@ export default function SellerDashboard() {
                                 <tbody>
                                   {group.orders.map((order) => (
                                     <tr key={order.id} className="border-b align-top">
-                                      <td className="py-2 px-4 font-medium">#{order.id}</td>
+                                      <td className="py-2 px-4 font-medium">#{order.code}</td>
                                       <td className="py-2 px-4">
                                         <ul className="space-y-1">
                                           {order.items.map((item) => (
@@ -533,7 +533,7 @@ export default function SellerDashboard() {
                       <div key={order.id} className="border rounded-lg p-4">
                         <div className="flex flex-col sm:flex-row sm:justify-between mb-4 gap-2">
                           <div>
-                            <h3 className="font-medium">Order #{order.id}</h3>
+                            <h3 className="font-medium">Order #{order.code}</h3>
                             <p className="text-sm text-gray-500 flex items-center">
                               <CalendarIcon className="h-3 w-3 mr-1" />
                               Placed on {formatDate(order.createdAt)}


### PR DESCRIPTION
## Summary
- show `order.code` on the order confirmation page
- display order codes in seller dashboard lists

## Testing
- `npm run check` *(fails: Cannot install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685d97164a6883309bad5a256923c153