### PR TITLE
Fix chat timezone and scrolling

### DIFF
--- a/client/src/components/messages/chat-message.tsx
+++ b/client/src/components/messages/chat-message.tsx
@@ -1,5 +1,6 @@
 import { Message } from "@shared/schema";
 import { format, parseISO } from "date-fns";
+import { utcToZonedTime } from "date-fns-tz";
 
 interface ChatMessageProps {
   message: Message;
@@ -18,7 +19,13 @@ export default function ChatMessage({ message, isOwn }: ChatMessageProps) {
       >
         {message.content}
         <div className="text-[10px] text-gray-500 mt-1 text-right">
-          {format(parseISO(message.createdAt as unknown as string), "p")}
+          {format(
+            utcToZonedTime(
+              parseISO(message.createdAt as unknown as string),
+              Intl.DateTimeFormat().resolvedOptions().timeZone,
+            ),
+            "p",
+          )}
         </div>
       </div>
     </div>

--- a/client/src/pages/order-messages.tsx
+++ b/client/src/pages/order-messages.tsx
@@ -12,18 +12,12 @@ export default function OrderMessagesPage() {
   const { user } = useAuth();
   const { data: messages = [], isLoading, sendMessage, markRead } = useMessages(orderId);
   const inputRef = useRef<HTMLInputElement>(null);
-  const bottomRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     if (orderId) {
       markRead.mutate();
     }
   }, [orderId]);
-
-  useEffect(() => {
-    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
-  }, [messages]);
-
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     const value = inputRef.current?.value.trim();
@@ -45,7 +39,6 @@ export default function OrderMessagesPage() {
               <ChatMessage key={m.id} message={m} isOwn={m.senderId === user?.id} />
             ))
           )}
-          <div ref={bottomRef} />
         </div>
         <form onSubmit={handleSubmit} className="mt-2 flex gap-2">
           <input

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "cmdk": "^1.1.1",
     "connect-pg-simple": "^10.0.0",
     "date-fns": "^3.6.0",
+    "date-fns-tz": "^3.0.0",
     "drizzle-orm": "^0.39.1",
     "drizzle-zod": "^0.7.0",
     "embla-carousel-react": "^8.6.0",


### PR DESCRIPTION
## Summary
- detect client timezone when rendering message timestamps
- remove autoscroll to message input
- add date-fns-tz dependency

## Testing
- `npm run check` *(fails: Cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_685d99b1007c83308131dd5d597e0b34