### PR TITLE
Handle product variations in offers

### DIFF
--- a/client/src/pages/buyer/offers.tsx
+++ b/client/src/pages/buyer/offers.tsx
@@ -5,7 +5,9 @@ import Footer from "@/components/layout/footer";
 import { formatCurrency } from "@/lib/utils";
 
 export default function BuyerOffersPage() {
-  const { data: offers = [] } = useQuery<Offer[]>({
+  type OfferWithProduct = Offer & { productTitle: string };
+
+  const { data: offers = [] } = useQuery<OfferWithProduct[]>({
     queryKey: ["/api/offers"],
   });
 
@@ -19,7 +21,14 @@ export default function BuyerOffersPage() {
             <div key={o.id} className="border p-4 rounded">
               <div className="flex justify-between">
                 <div>
-                  <p className="font-medium">Offer #{o.id}</p>
+                  <p className="font-medium">{o.productTitle}</p>
+                  {o.selectedVariations && (
+                    <p className="text-sm text-gray-500">
+                      {Object.entries(o.selectedVariations)
+                        .map(([k, v]) => `${k}: ${v}`)
+                        .join(", ")}
+                    </p>
+                  )}
                   <p className="text-sm">Quantity: {o.quantity}</p>
                 </div>
                 <div className="text-right">

--- a/client/src/pages/product-detail-page.tsx
+++ b/client/src/pages/product-detail-page.tsx
@@ -69,7 +69,7 @@ export default function ProductDetailPage() {
   });
 
   const offerMutation = useMutation({
-    mutationFn: (data: { price: number; quantity: number }) =>
+    mutationFn: (data: { price: number; quantity: number; selectedVariations?: Record<string, string> }) =>
       apiRequest("POST", `/api/products/${productId}/offers`, data),
     onSuccess: () => {
       toast({ title: "Offer sent" });
@@ -296,7 +296,7 @@ export default function ProductDetailPage() {
 
             {user?.role === "buyer" && (
               <>
-                <MakeOfferDialog onSubmit={(p, q) => offerMutation.mutate({ price: p, quantity: q })} />
+                <MakeOfferDialog onSubmit={(p, q) => offerMutation.mutate({ price: p, quantity: q, selectedVariations })} />
                 <AskQuestionDialog onSubmit={q => questionMutation.mutate(q)} />
               </>
             )}

--- a/client/src/pages/seller/dashboard.tsx
+++ b/client/src/pages/seller/dashboard.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useMemo } from "react";
 import { Link, useLocation } from "wouter";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { Order, OrderItem, Product, Address, PaymentMethod } from "@shared/schema";
+import { Order, OrderItem, Product, Address, PaymentMethod, Offer } from "@shared/schema";
 import Header from "@/components/layout/header";
 import Footer from "@/components/layout/footer";
 import {
@@ -91,6 +91,21 @@ export default function SellerDashboard() {
     queryKey: ["/api/payment-methods"],
     enabled: !!user,
   });
+
+  type OfferWithProduct = Offer & { productTitle: string };
+
+  const { data: offers = [] } = useQuery<OfferWithProduct[]>({
+    queryKey: ["/api/offers"],
+    enabled: !!user,
+  });
+
+  const [offersOpen, setOffersOpen] = useState(false);
+
+  useEffect(() => {
+    if (offers.some((o) => o.status === "pending")) {
+      setOffersOpen(true);
+    }
+  }, [offers]);
 
   const queryClient = useQueryClient();
   const { toast } = useToast();
@@ -744,6 +759,70 @@ export default function SellerDashboard() {
               </DialogClose>
               <Button onClick={handleConfirmTracking} disabled={!trackingNum}>Confirm</Button>
             </DialogFooter>
+          </DialogContent>
+        </Dialog>
+
+        <Dialog open={offersOpen} onOpenChange={setOffersOpen}>
+          <DialogContent className="sm:max-w-[600px]">
+            <DialogHeader>
+              <DialogTitle>Recent Offers</DialogTitle>
+            </DialogHeader>
+            <div className="space-y-4 max-h-96 overflow-y-auto">
+              {offers.length === 0 ? (
+                <p>No offers.</p>
+              ) : (
+                offers.map((o) => (
+                  <div key={o.id} className="border p-3 rounded flex justify-between">
+                    <div>
+                      <p className="font-medium">{o.productTitle}</p>
+                      {o.selectedVariations && (
+                        <p className="text-xs text-gray-500">
+                          {Object.entries(o.selectedVariations)
+                            .map(([k, v]) => `${k}: ${v}`)
+                            .join(", ")}
+                        </p>
+                      )}
+                      <p className="text-sm">Qty: {o.quantity}</p>
+                      <p className="text-sm">{formatCurrency(o.price)}</p>
+                    </div>
+                    {o.status === "pending" && (
+                      <div className="space-x-2 flex items-start">
+                        <Button
+                          size="sm"
+                          onClick={() =>
+                            apiRequest("POST", `/api/offers/${o.id}/accept`)
+                              .then(() => {
+                                queryClient.invalidateQueries({ queryKey: ["/api/offers"] });
+                                setOffersOpen(false);
+                                toast({ title: "Offer accepted" });
+                              })
+                          }
+                        >
+                          Accept
+                        </Button>
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          onClick={() =>
+                            apiRequest("POST", `/api/offers/${o.id}/reject`)
+                              .then(() => {
+                                queryClient.invalidateQueries({ queryKey: ["/api/offers"] });
+                                setOffersOpen(false);
+                                toast({ title: "Offer rejected" });
+                              })
+                          }
+                        >
+                          Reject
+                        </Button>
+                      </div>
+                    )}
+                  </div>
+                ))
+              )}
+              <div className="text-right">
+                <Link href="/seller/offers">View All</Link>
+              </div>
+            </div>
           </DialogContent>
         </Dialog>
       </>

--- a/client/src/pages/seller/offers.tsx
+++ b/client/src/pages/seller/offers.tsx
@@ -11,7 +11,9 @@ export default function SellerOffersPage() {
   const queryClient = useQueryClient();
   const { toast } = useToast();
 
-  const { data: offers = [], isLoading } = useQuery<Offer[]>({
+  type OfferWithProduct = Offer & { productTitle: string };
+
+  const { data: offers = [], isLoading } = useQuery<OfferWithProduct[]>({
     queryKey: ["/api/offers"],
   });
 
@@ -60,8 +62,14 @@ export default function SellerOffersPage() {
           offers.map((o) => (
             <div key={o.id} className="border p-4 rounded flex justify-between">
               <div>
-                <p className="font-medium">Offer #{o.id} for product #{o.productId}</p>
-                <p className="text-sm">Buyer #{o.buyerId}</p>
+                <p className="font-medium">{o.productTitle}</p>
+                {o.selectedVariations && (
+                  <p className="text-sm text-gray-500">
+                    {Object.entries(o.selectedVariations)
+                      .map(([k, v]) => `${k}: ${v}`)
+                      .join(", ")}
+                  </p>
+                )}
                 <p className="text-sm">Quantity: {o.quantity}</p>
                 <p className="text-sm">Price: {formatCurrency(o.price)}</p>
                 <span className="text-xs capitalize">Status: {o.status}</span>

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -213,7 +213,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
         userId: product.sellerId,
         type: 'offer',
         content: `New offer for ${product.title}`,
-        link: `/seller/orders`,
+        link: `/seller/offers`,
       });
 
       res.status(201).json(offer);
@@ -1059,6 +1059,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
           quantity: offer.quantity,
           unitPrice: offer.price,
           totalPrice: offer.price * offer.quantity,
+          selectedVariations: offer.selectedVariations ?? null,
         });
 
         await tx.insert(orderItemsTable).values(orderItemData);
@@ -1071,6 +1072,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
             quantity: offer.quantity,
             unitPrice: offer.price,
             totalPrice: offer.price * offer.quantity,
+            selectedVariations: offer.selectedVariations ?? undefined,
             image: product.images?.[0],
           });
         }

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -322,6 +322,7 @@ export const offers = pgTable("offers", {
   sellerId: integer("seller_id").notNull(),
   price: doublePrecision("price").notNull(),
   quantity: integer("quantity").notNull(),
+  selectedVariations: jsonb("selected_variations"),
   status: text("status").notNull().default("pending"), // pending, accepted, rejected
   orderId: integer("order_id"),
   createdAt: timestamp("created_at").defaultNow(),
@@ -335,7 +336,8 @@ export const offersRelations = relations(offers, ({ one }) => ({
 }));
 
 export const insertOfferSchema = createInsertSchema(offers)
-  .omit({ id: true, status: true, orderId: true, createdAt: true });
+  .omit({ id: true, status: true, orderId: true, createdAt: true })
+  .extend({ selectedVariations: z.record(z.string()).optional().nullable() });
 
 // Support tickets that buyers and sellers can create
 export const supportTickets = pgTable("support_tickets", {


### PR DESCRIPTION
## Summary
- record selected variations when buyers submit offers
- join offers with products so API returns product titles
- notify sellers about offers with a link to the offers page
- show offer product titles/variations on buyer and seller views
- allow sellers to manage offers from a popup on the dashboard
- include selected variations when converting an offer into an order

## Testing
- `npm run check` *(fails: Cannot find module 'wouter' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_685d987dc2348330b7267c36ceaf5dac