### PR TITLE
Fix hero button opacity

### DIFF
--- a/client/src/components/home/hero.tsx
+++ b/client/src/components/home/hero.tsx
@@ -26,7 +26,7 @@ export default function Hero() {
             <Button
               size="lg"
               variant="secondary"
-              className="bg-white/80 text-primary hover:bg-white"
+              className="bg-white/90 text-primary hover:bg-white"
             >
               Become a Seller
             </Button>


### PR DESCRIPTION
## Summary
- tweak hero's Become a Seller button so white is more opaque

## Testing
- `npm run check` *(fails: cannot reach registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_685f0fe4ac0c83308e9fa7e3d0272118