### PR TITLE
Use initials when no avatar is set

### DIFF
--- a/client/src/components/layout/header-fixed.tsx
+++ b/client/src/components/layout/header-fixed.tsx
@@ -121,7 +121,7 @@ export default function Header() {
                   <DropdownMenuTrigger asChild>
                     <Button variant="ghost" className="relative h-8 w-8 rounded-full">
                       <Avatar className="h-8 w-8">
-                        <AvatarImage src={user.avatarUrl || "https://github.com/shadcn.png"} alt={user.username} />
+                        <AvatarImage src={user.avatarUrl || undefined} alt={user.username} />
                         <AvatarFallback>{user.firstName.charAt(0)}{user.lastName.charAt(0)}</AvatarFallback>
                       </Avatar>
                     </Button>
@@ -215,7 +215,7 @@ export default function Header() {
                 <div className="flex items-center px-4">
                   <div className="flex-shrink-0">
                     <Avatar className="h-10 w-10">
-                      <AvatarImage src={user.avatarUrl || "https://github.com/shadcn.png"} alt={user.username} />
+                      <AvatarImage src={user.avatarUrl || undefined} alt={user.username} />
                       <AvatarFallback>{user.firstName.charAt(0)}{user.lastName.charAt(0)}</AvatarFallback>
                     </Avatar>
                   </div>

--- a/client/src/components/layout/header.tsx
+++ b/client/src/components/layout/header.tsx
@@ -160,7 +160,7 @@ export default function Header({ dashboardTabs, onProfileClick }: HeaderProps) {
                   <DropdownMenuTrigger asChild>
                     <Button variant="ghost" className="relative h-8 w-8 rounded-full">
                       <Avatar className="h-8 w-8">
-                        <AvatarImage src={user.avatarUrl || "https://github.com/shadcn.png"} alt={user.username} />
+                        <AvatarImage src={user.avatarUrl || undefined} alt={user.username} />
                         <AvatarFallback>
                           {user.firstName.charAt(0)}
                           {user.lastName.charAt(0)}
@@ -258,7 +258,7 @@ export default function Header({ dashboardTabs, onProfileClick }: HeaderProps) {
                 <div className="flex items-center px-4">
                   <div className="flex-shrink-0">
                     <Avatar className="h-10 w-10">
-                      <AvatarImage src={user.avatarUrl || "https://github.com/shadcn.png"} alt={user.username} />
+                      <AvatarImage src={user.avatarUrl || undefined} alt={user.username} />
                       <AvatarFallback>
                         {user.firstName.charAt(0)}
                         {user.lastName.charAt(0)}

--- a/client/src/components/messages/conversation-preview.tsx
+++ b/client/src/components/messages/conversation-preview.tsx
@@ -31,7 +31,7 @@ export default function ConversationPreview({ otherId, selected }: ConversationP
       className={`relative flex items-center gap-3 p-3 border-b hover:bg-gray-50 ${selected ? "bg-gray-50" : ""}`}
     >
       <Avatar>
-        <AvatarImage src={user?.avatarUrl || "https://github.com/shadcn.png"} alt={user?.username} />
+        <AvatarImage src={user?.avatarUrl || undefined} alt={user?.username} />
         <AvatarFallback>
           {user?.firstName?.charAt(0)}
           {user?.lastName?.charAt(0)}

--- a/client/src/pages/buyer/profile.tsx
+++ b/client/src/pages/buyer/profile.tsx
@@ -33,7 +33,7 @@ export default function BuyerProfilePage() {
             <CardContent className="p-4 sm:p-6">
               <div className="flex flex-col items-center">
                 <Avatar className="h-24 w-24 mb-4">
-                  <AvatarImage src={user?.avatarUrl || "https://github.com/shadcn.png"} alt={user?.username} />
+                  <AvatarImage src={user?.avatarUrl || undefined} alt={user?.username} />
                   <AvatarFallback className="text-lg">
                     {user?.firstName?.charAt(0)}{user?.lastName?.charAt(0)}
                   </AvatarFallback>

--- a/client/src/pages/seller/dashboard.tsx
+++ b/client/src/pages/seller/dashboard.tsx
@@ -682,7 +682,7 @@ export default function SellerDashboard() {
                 <CardContent>
                   <div className="flex flex-col items-center">
                     <Avatar className="h-24 w-24 mb-4">
-                      <AvatarImage src={user?.avatarUrl || "https://github.com/shadcn.png"} alt={user?.username} />
+                      <AvatarImage src={user?.avatarUrl || undefined} alt={user?.username} />
                       <AvatarFallback className="text-lg">
                         {user?.firstName?.charAt(0)}{user?.lastName?.charAt(0)}
                       </AvatarFallback>


### PR DESCRIPTION
## Summary
- show initials instead of placeholder avatar image across the UI

## Testing
- `npm run check` *(fails: Cannot find module 'wouter' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_685f1225a69c8330a7d2c72198e11373