### PR TITLE
Add listing preview to message pages

### DIFF
--- a/client/src/components/messages/listing-banner.tsx
+++ b/client/src/components/messages/listing-banner.tsx
@@ -1,0 +1,19 @@
+import { Link } from "wouter";
+
+interface ListingBannerProps {
+  productId: number;
+  title: string;
+  image: string;
+}
+
+export default function ListingBanner({ productId, title, image }: ListingBannerProps) {
+  return (
+    <Link
+      href={`/products/${productId}`}
+      className="flex items-center gap-3 p-2 border rounded mb-2 bg-white shadow-sm hover:bg-gray-50"
+    >
+      <img src={image} alt={title} className="w-16 h-16 object-cover rounded" />
+      <span className="font-medium truncate">{title}</span>
+    </Link>
+  );
+}

--- a/client/src/pages/order-messages.tsx
+++ b/client/src/pages/order-messages.tsx
@@ -5,13 +5,27 @@ import { useMessages } from "@/hooks/use-messages";
 import { useAuth } from "@/hooks/use-auth";
 import { useEffect, useRef } from "react";
 import ChatMessage from "@/components/messages/chat-message";
+import { useQuery } from "@tanstack/react-query";
+import { Order, OrderItem } from "@shared/schema";
+import ListingBanner from "@/components/messages/listing-banner";
+
+interface OrderItemWithProduct extends OrderItem {
+  productTitle: string;
+  productImages: string[];
+}
 
 export default function OrderMessagesPage() {
   const { id } = useParams();
   const orderId = parseInt(id);
   const { user } = useAuth();
+  const { data: order } = useQuery<Order & { items: OrderItemWithProduct[] }>({
+    queryKey: ["/api/orders/" + orderId],
+    enabled: !Number.isNaN(orderId),
+  });
   const { data: messages = [], isLoading, sendMessage, markRead } = useMessages(orderId);
   const inputRef = useRef<HTMLInputElement>(null);
+
+  const listing = order?.items?.[0];
 
   useEffect(() => {
     if (orderId) {
@@ -31,6 +45,13 @@ export default function OrderMessagesPage() {
       <Header />
       <main className="max-w-2xl mx-auto px-4 py-4 flex flex-col h-[calc(100vh-8rem)]">
         <h1 className="text-xl font-semibold mb-2">Order Messages</h1>
+        {listing && (
+          <ListingBanner
+            productId={listing.productId}
+            title={listing.productTitle}
+            image={listing.productImages[0]}
+          />
+        )}
         <div className="flex-1 overflow-y-auto space-y-2 bg-gray-50 border rounded p-4">
           {isLoading ? (
             <p>Loading...</p>


### PR DESCRIPTION
## Summary
- add a `ListingBanner` component for quick product previews
- show the related listing on top of conversation and order messages pages

## Testing
- `npm run check` *(fails: Cannot find module '@vitejs/plugin-react' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_685f1270ffa083308ac7b32db85d87e5