### PR TITLE
Remove unused admin nav buttons

### DIFF
--- a/client/src/components/layout/header.tsx
+++ b/client/src/components/layout/header.tsx
@@ -63,7 +63,7 @@ export default function Header({ dashboardTabs, onProfileClick }: HeaderProps) {
               </div>
               <nav className="hidden sm:ml-6 sm:flex sm:space-x-8 items-center">
                 {[
-                  !(user && user.role === "seller") && { label: "Home", href: "/" },
+                  !(user && user.role === "seller") && user?.role !== "admin" && { label: "Home", href: "/" },
                   { label: "Products", href: "/products" },
                   user?.role === "buyer" && {
                     label: "My Orders",

--- a/client/src/pages/admin/dashboard.tsx
+++ b/client/src/pages/admin/dashboard.tsx
@@ -104,15 +104,7 @@ export default function AdminDashboard() {
     >
       <Header
         dashboardTabs={
-          <TabsList className="grid grid-cols-3 md:flex md:w-auto">
-            <TabsTrigger value="overview">
-              <LayoutDashboard className="h-4 w-4 mr-2" />
-              Overview
-            </TabsTrigger>
-            <TabsTrigger value="users">
-              <Users className="h-4 w-4 mr-2" />
-              Users
-            </TabsTrigger>
+          <TabsList className="grid grid-cols-1 md:flex md:w-auto">
             <TabsTrigger value="sales">
               <BarChart4 className="h-4 w-4 mr-2" />
               Sales


### PR DESCRIPTION
## Summary
- hide `Home` link for admins in the main header
- only show the `Sales` tab in the admin dashboard

## Testing
- `npm run check` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6862abc4d9408330a52f614427b0936b