### PR TITLE
Add HTML wire instructions email

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,4 +20,4 @@ Any new address or card entered during checkout is saved to your profile automat
 
 ## Shipment Tracking
 To automatically update order statuses from tracking numbers, set the `TRACKTRY_API_KEY` environment variable with your Tracktry.com API key.
-For wire transfer payments, configure `WIRE_INSTRUCTIONS` with the bank details you want emailed to buyers.
+For wire transfer payments, configure `WIRE_INSTRUCTIONS` with the bank details you want emailed to buyers. If not set, the server uses account number `12345678` and routing number `12345678` in the wire instructions email.

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -510,7 +510,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       // send invoice email asynchronously, do not block response
       sendInvoiceEmail(user.email, order, invoiceItems, user).catch(console.error);
       if (order.paymentDetails?.method === "wire") {
-        sendWireInstructionsEmail(user.email, order.code).catch(console.error);
+        sendWireInstructionsEmail(user.email, order).catch(console.error);
       }
 
       // notify seller of the new order


### PR DESCRIPTION
## Summary
- add html version of wire transfer email
- include account and routing numbers when `WIRE_INSTRUCTIONS` is unset
- update wire instructions invocation for new API
- document the defaults in the README

## Testing
- `npm run check` *(fails: cannot install deps)*

------
https://chatgpt.com/codex/tasks/task_e_6862b143167c833099e4db6be175bf33