### PR TITLE
Round up service fee

### DIFF
--- a/client/src/components/home/banner-carousel.tsx
+++ b/client/src/components/home/banner-carousel.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 
 import { Product } from "@shared/schema";
-import { formatCurrency, SERVICE_FEE_RATE } from "@/lib/utils";
+import { formatCurrency, addServiceFee } from "@/lib/utils";
 import { useAuth } from "@/hooks/use-auth";
 import {
   Carousel,
@@ -61,7 +61,7 @@ export default function BannerCarousel() {
             {inStockProducts.map((product) => {
               const price =
                 !user || user.role === "buyer"
-                  ? product.price * (1 + SERVICE_FEE_RATE)
+                  ? addServiceFee(product.price)
                   : product.price;
               return (
                 <CarouselItem key={product.id} className="basis-full h-full">

--- a/client/src/components/products/product-card.tsx
+++ b/client/src/components/products/product-card.tsx
@@ -4,7 +4,7 @@ import { ShoppingCart } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { formatCurrency, SERVICE_FEE_RATE } from "@/lib/utils";
+import { formatCurrency, addServiceFee } from "@/lib/utils";
 import { useCart } from "@/hooks/use-cart";
 import { useAuth } from "@/hooks/use-auth";
 
@@ -25,7 +25,7 @@ export default function ProductCard({ product }: ProductCardProps) {
   const { user } = useAuth();
   const displayPrice =
     !user || user.role === "buyer"
-      ? product.price * (1 + SERVICE_FEE_RATE)
+      ? addServiceFee(product.price)
       : product.price;
   
   const handleAddToCart = () => {

--- a/client/src/hooks/use-cart.tsx
+++ b/client/src/hooks/use-cart.tsx
@@ -2,7 +2,7 @@ import { createContext, ReactNode, useContext, useState, useEffect } from "react
 import { CartItem, Product } from "@shared/schema";
 import { useToast } from "@/hooks/use-toast";
 import { useAuth } from "@/hooks/use-auth";
-import { SERVICE_FEE_RATE } from "@/lib/utils";
+import { addServiceFee } from "@/lib/utils";
 
 interface CartContextType {
   items: CartItem[];
@@ -46,7 +46,7 @@ export function CartProvider({ children }: { children: ReactNode }) {
             orderMultiple: item.orderMultiple ?? 1,
             price:
               !user || user.role === "buyer"
-                ? parseFloat((item.price * (1 + SERVICE_FEE_RATE)).toFixed(2))
+                ? addServiceFee(item.price)
                 : item.price,
           }))
         );
@@ -110,7 +110,7 @@ export function CartProvider({ children }: { children: ReactNode }) {
         : product.price;
     const priceWithFee =
       !user || user.role === "buyer"
-        ? parseFloat((basePrice * (1 + SERVICE_FEE_RATE)).toFixed(2))
+        ? addServiceFee(basePrice)
         : basePrice;
 
       setItems(prevItems => {

--- a/client/src/lib/utils.ts
+++ b/client/src/lib/utils.ts
@@ -7,6 +7,16 @@ export function cn(...inputs: ClassValue[]) {
 
 export const SERVICE_FEE_RATE = 0.035;
 
+// Round a number up to the nearest cent
+export function roundUpToCent(amount: number): number {
+  return Math.ceil(amount * 100) / 100;
+}
+
+// Apply the service fee and round up to the nearest cent
+export function addServiceFee(basePrice: number): number {
+  return roundUpToCent(basePrice * (1 + SERVICE_FEE_RATE));
+}
+
 export function formatCurrency(amount: number): string {
   return new Intl.NumberFormat('en-US', {
     style: 'currency',

--- a/client/src/pages/product-detail-page.tsx
+++ b/client/src/pages/product-detail-page.tsx
@@ -31,7 +31,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Input } from "@/components/ui/input";
-import { formatCurrency, SERVICE_FEE_RATE } from "@/lib/utils";
+import { formatCurrency, addServiceFee } from "@/lib/utils";
 import { useAuth } from "@/hooks/use-auth";
 import { useCart } from "@/hooks/use-cart";
 import { apiRequest } from "@/lib/queryClient";
@@ -126,7 +126,7 @@ export default function ProductDetailPage() {
       : product?.price ?? 0;
   const unitPrice =
     product && (!user || user.role === "buyer")
-      ? basePrice * (1 + SERVICE_FEE_RATE)
+      ? addServiceFee(basePrice)
       : basePrice;
   const totalCost = product ? unitPrice * quantity : 0;
 

--- a/client/src/pages/products-page.tsx
+++ b/client/src/pages/products-page.tsx
@@ -7,7 +7,7 @@ import ProductCard from "@/components/products/product-card";
 import ProductFilter from "@/components/products/product-filter";
 import { Button } from "@/components/ui/button";
 import { Loader2, Grid3X3, List, ShoppingCart } from "lucide-react";
-import { formatCurrency, SERVICE_FEE_RATE } from "@/lib/utils";
+import { formatCurrency, addServiceFee } from "@/lib/utils";
 import { useAuth } from "@/hooks/use-auth";
 
 export default function ProductsPage() {
@@ -168,7 +168,7 @@ export default function ProductsPage() {
                   <div className="ml-4 flex flex-col flex-1">
                     <h3 className="text-sm font-medium text-gray-900 line-clamp-2">{product.title}</h3>
                     <p className="text-base font-semibold text-green-600">
-                      {formatCurrency((!user || user.role === 'buyer') ? product.price * (1 + SERVICE_FEE_RATE) : product.price)}
+                      {formatCurrency((!user || user.role === 'buyer') ? addServiceFee(product.price) : product.price)}
                       /unit
                     </p>
                     {product.retailMsrp && (


### PR DESCRIPTION
## Summary
- add helper to apply the 3.5% service fee rounding up to the nearest cent
- use this helper when displaying product prices in cards, listings and detail pages
- update cart logic so persisted prices include the rounding

## Testing
- `npm run check` *(fails: Cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_68642bba45788330a7bec7c03d6d9619