### PR TITLE
Extend order number complexity

### DIFF
--- a/server/orderCode.ts
+++ b/server/orderCode.ts
@@ -1,5 +1,7 @@
+import { randomBytes } from "crypto";
+
 export function generateOrderCode(id: number): string {
-  const multiplier = 9973; // prime number
-  const offset = 12345;
-  return 'O' + ((id * multiplier + offset).toString(36).toUpperCase());
+  const idPart = id.toString(36).toUpperCase().padStart(6, "0");
+  const randomPart = randomBytes(3).toString("hex").toUpperCase();
+  return `O${idPart}${randomPart}`;
 }


### PR DESCRIPTION
## Summary
- lengthen the generated order code and add randomness

## Testing
- `npm run check` *(fails: Cannot find module / missing types)*

------
https://chatgpt.com/codex/tasks/task_e_68642c38ba3483309fa90a3cc1d2a191