### PR TITLE
Require resale certificate and remove sales tax

### DIFF
--- a/client/src/components/cart/cart-drawer.tsx
+++ b/client/src/components/cart/cart-drawer.tsx
@@ -62,11 +62,6 @@ export default function CartDrawer() {
                 <p>Shipping</p>
                 <p>Calculated at checkout</p>
               </div>
-              <div className="flex justify-between text-sm text-gray-500 mb-4">
-                <p>Taxes</p>
-                <p>Calculated at checkout</p>
-              </div>
-              
               <SheetFooter>
                 <SheetClose asChild>
                   <Link href="/checkout">

--- a/client/src/hooks/use-auth.tsx
+++ b/client/src/hooks/use-auth.tsx
@@ -30,7 +30,7 @@ export const registerSchema = z.object({
   zipCode: z.string().min(1, "ZIP code is required"),
   country: z.string().default("United States"),
   role: z.string().default("buyer"),
-  resaleCertUrl: z.string().optional(),
+  resaleCertUrl: z.string().min(1, "Resale certificate is required"),
   confirmPassword: z.string(),
 }).refine((data) => data.password === data.confirmPassword, {
   message: "Passwords don't match",

--- a/client/src/pages/buyer/signup.tsx
+++ b/client/src/pages/buyer/signup.tsx
@@ -309,7 +309,7 @@ export default function BuyerSignupPage() {
                       name="resaleCertUrl"
                       render={({ field }) => (
                         <FormItem>
-                          <FormLabel>Resale Certificate (Optional)</FormLabel>
+                          <FormLabel>Resale Certificate</FormLabel>
                           <FormControl>
                             <Input type="hidden" {...field} />
                           </FormControl>

--- a/client/src/pages/cart-page.tsx
+++ b/client/src/pages/cart-page.tsx
@@ -99,11 +99,6 @@ export default function CartPage() {
                     <div className="text-sm text-gray-900">Calculated at checkout</div>
                   </div>
                   
-                  <div className="flex justify-between">
-                    <div className="text-sm text-gray-600">Taxes</div>
-                    <div className="text-sm text-gray-900">Calculated at checkout</div>
-                  </div>
-                  
                   <Separator />
                   
                   <div className="flex justify-between">

--- a/client/src/pages/checkout-page.tsx
+++ b/client/src/pages/checkout-page.tsx
@@ -720,11 +720,6 @@ export default function CheckoutPage() {
                     <div className="text-sm text-gray-900">Calculated at next step</div>
                   </div>
 
-                  <div className="flex justify-between">
-                    <div className="text-sm text-gray-600">Taxes</div>
-                    <div className="text-sm text-gray-900">Calculated at next step</div>
-                  </div>
-
                   <Separator />
 
                   <div className="flex justify-between">

--- a/client/src/pages/seller-agreement.tsx
+++ b/client/src/pages/seller-agreement.tsx
@@ -17,7 +17,7 @@ export default function SellerAgreementPage() {
           <h2>Listings</h2>
           <p>All listings must accurately describe inventory and comply with applicable laws. Misleading or prohibited items may be removed without notice.</p>
           <h2>Payments</h2>
-          <p>Payments are processed through our secure payment provider. Sellers are responsible for any applicable fees and taxes.</p>
+          <p>Payments are processed through our secure payment provider. Sellers are responsible for any applicable fees.</p>
           <h2>Disputes</h2>
           <p>Any disputes with buyers should be reported promptly. SY Closeouts reserves the right to mediate or suspend accounts that violate these terms.</p>
           <h2>Termination</h2>

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -135,7 +135,11 @@ export function setupAuth(app: Express) {
         ...userFields
       } = req.body;
 
-      const resaleCertStatus = resaleCertUrl ? "pending" : "none";
+      if (!resaleCertUrl) {
+        return res.status(400).json({ error: "Resale certificate is required" });
+      }
+
+      const resaleCertStatus = "pending";
 
       const user = await storage.createUser({
         ...userFields,

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -424,13 +424,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
         }
       }
 
-      const state = (orderData.shippingDetails as any)?.state as string | undefined;
-      const taxRates: Record<string, number> = { CA: 0.0725, NY: 0.08875 };
-      const taxRate = state ? taxRates[state] ?? 0.06 : 0;
       let totalAmount = sellerTotal;
-      if (user.resaleCertStatus !== "approved") {
-        totalAmount += sellerTotal * taxRate;
-      }
       orderData.totalAmount = totalAmount;
 
       if (orderData.paymentDetails && orderData.paymentDetails.method === "wire") {


### PR DESCRIPTION
## Summary
- make resale certificate mandatory on signup
- remove tax calculation on orders
- drop taxes from the UI and seller agreement

## Testing
- `npm run check` *(fails: Cannot find module '@vitejs/plugin-react', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68642d53e6648330bb8754d0910fad0b