### PR TITLE
Add admin email template management

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -45,6 +45,7 @@ import HelpPage from "@/pages/help-page";
 import AdminTicketsPage from "@/pages/admin/tickets";
 import AdminMessagesPage from "@/pages/admin/messages";
 import AdminUserProfilePage from "@/pages/admin/user-profile";
+import AdminEmailTemplatesPage from "@/pages/admin/email-templates";
 import AboutPage from "@/pages/about-page";
 import SellerAgreementPage from "@/pages/seller-agreement";
 import BuyerAgreementPage from "@/pages/buyer-agreement";
@@ -107,6 +108,7 @@ function Router() {
       <ProtectedRoute path="/admin/applications" component={AdminApplications} allowedRoles={["admin"]} />
       <ProtectedRoute path="/admin/featured" component={FeaturedProductsPage} allowedRoles={["admin"]} />
       <ProtectedRoute path="/admin/messages" component={AdminMessagesPage} allowedRoles={["admin"]} />
+      <ProtectedRoute path="/admin/email-templates" component={AdminEmailTemplatesPage} allowedRoles={["admin"]} />
       <ProtectedRoute path="/admin/tickets" component={AdminTicketsPage} allowedRoles={["admin"]} />
 
       {/* Fallback to 404 */}

--- a/client/src/components/layout/header.tsx
+++ b/client/src/components/layout/header.tsx
@@ -88,6 +88,10 @@ export default function Header({ dashboardTabs, onProfileClick }: HeaderProps) {
                     label: "Messages",
                     href: "/admin/messages",
                   },
+                  user?.role === "admin" && {
+                    label: "Emails",
+                    href: "/admin/email-templates",
+                  },
                   { label: "About", href: "/about" },
                 ]
                   .filter(Boolean)

--- a/client/src/hooks/use-email-templates.tsx
+++ b/client/src/hooks/use-email-templates.tsx
@@ -1,0 +1,41 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { EmailTemplate } from "@shared/schema";
+import { apiRequest } from "@/lib/queryClient";
+
+export function useEmailTemplates() {
+  return useQuery<EmailTemplate[]>({
+    queryKey: ["/api/admin/email-templates"],
+  });
+}
+
+export function useCreateEmailTemplate() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (data: { name: string; subject: string; body: string }) =>
+      apiRequest("POST", "/api/admin/email-templates", data).then(r => r.json()),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["/api/admin/email-templates"] }),
+  });
+}
+
+export function useUpdateEmailTemplate() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (data: { id: number; values: Partial<EmailTemplate> }) =>
+      apiRequest("PUT", `/api/admin/email-templates/${data.id}`, data.values).then(r => r.json()),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["/api/admin/email-templates"] }),
+  });
+}
+
+export function useDeleteEmailTemplate() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: number) => apiRequest("DELETE", `/api/admin/email-templates/${id}`),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["/api/admin/email-templates"] }),
+  });
+}
+
+export function useSendEmailTemplate() {
+  return useMutation((data: { id: number; group: string }) =>
+    apiRequest("POST", `/api/admin/email-templates/${data.id}/send`, { group: data.group })
+  );
+}

--- a/client/src/pages/admin/dashboard.tsx
+++ b/client/src/pages/admin/dashboard.tsx
@@ -31,7 +31,8 @@ import {
   Package,
   Star,
   DollarSign,
-  Banknote
+  Banknote,
+  Mail
 } from "lucide-react";
 import { useAuth } from "@/hooks/use-auth";
 import { formatCurrency, SERVICE_FEE_RATE } from "@/lib/utils";
@@ -156,6 +157,12 @@ export default function AdminDashboard() {
               <Button variant="outline" className="flex items-center">
                 <Star className="mr-2 h-4 w-4" />
                 Featured Products
+              </Button>
+            </Link>
+            <Link href="/admin/email-templates">
+              <Button variant="outline" className="flex items-center">
+                <Mail className="mr-2 h-4 w-4" />
+                Email Templates
               </Button>
             </Link>
           </div>

--- a/client/src/pages/admin/email-templates.tsx
+++ b/client/src/pages/admin/email-templates.tsx
@@ -1,0 +1,115 @@
+import { useState, useEffect } from "react";
+import Header from "@/components/layout/header";
+import Footer from "@/components/layout/footer";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Button } from "@/components/ui/button";
+import { Table, TableHeader, TableRow, TableHead, TableBody, TableCell } from "@/components/ui/table";
+import { Loader2 } from "lucide-react";
+import {
+  useEmailTemplates,
+  useCreateEmailTemplate,
+  useUpdateEmailTemplate,
+  useDeleteEmailTemplate,
+  useSendEmailTemplate,
+} from "@/hooks/use-email-templates";
+import { EmailTemplate } from "@shared/schema";
+
+export default function AdminEmailTemplatesPage() {
+  const { data: templates = [], isLoading } = useEmailTemplates();
+  const create = useCreateEmailTemplate();
+  const update = useUpdateEmailTemplate();
+  const remove = useDeleteEmailTemplate();
+  const send = useSendEmailTemplate();
+
+  const [editing, setEditing] = useState<EmailTemplate | null>(null);
+  const [name, setName] = useState("{}");
+  const [subject, setSubject] = useState("{}");
+  const [body, setBody] = useState("{}");
+
+  useEffect(() => {
+    if (editing) {
+      setName(editing.name);
+      setSubject(editing.subject);
+      setBody(editing.body);
+    } else {
+      setName("");
+      setSubject("");
+      setBody("");
+    }
+  }, [editing]);
+
+  function submit() {
+    if (editing) {
+      update.mutate({ id: editing.id, values: { name, subject, body } });
+      setEditing(null);
+    } else {
+      create.mutate({ name, subject, body });
+    }
+  }
+
+  return (
+    <>
+      <Header />
+      <main className="max-w-7xl mx-auto px-4 py-8 space-y-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>{editing ? "Edit Template" : "New Template"}</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            <Input placeholder="Name" value={name} onChange={e => setName(e.target.value)} />
+            <Input placeholder="Subject" value={subject} onChange={e => setSubject(e.target.value)} />
+            <Textarea rows={6} placeholder="HTML Body" value={body} onChange={e => setBody(e.target.value)} />
+            <div className="flex gap-2">
+              <Button onClick={submit} disabled={create.isPending || update.isPending}>Save</Button>
+              {editing && (
+                <Button variant="outline" onClick={() => setEditing(null)}>Cancel</Button>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Saved Templates</CardTitle>
+          </CardHeader>
+          <CardContent>
+            {isLoading ? (
+              <div className="flex justify-center py-12"><Loader2 className="h-8 w-8 animate-spin" /></div>
+            ) : templates.length > 0 ? (
+              <div className="overflow-x-auto">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Name</TableHead>
+                      <TableHead>Subject</TableHead>
+                      <TableHead>Actions</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {templates.map(t => (
+                      <TableRow key={t.id}>
+                        <TableCell>{t.name}</TableCell>
+                        <TableCell>{t.subject}</TableCell>
+                        <TableCell className="space-x-2">
+                          <Button size="sm" variant="outline" onClick={() => setEditing(t)}>Edit</Button>
+                          <Button size="sm" variant="outline" onClick={() => remove.mutate(t.id)}>Delete</Button>
+                          <Button size="sm" onClick={() => send.mutate({ id: t.id, group: "buyers" })}>Buyers</Button>
+                          <Button size="sm" variant="secondary" onClick={() => send.mutate({ id: t.id, group: "sellers" })}>Sellers</Button>
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+            ) : (
+              <div className="text-center text-gray-500">No templates</div>
+            )}
+          </CardContent>
+        </Card>
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/server/email.ts
+++ b/server/email.ts
@@ -506,6 +506,28 @@ export async function sendAdminUserEmail(
   }
 }
 
+export async function sendHtmlEmail(to: string, subject: string, html: string) {
+  if (!transporter) {
+    console.warn("Email transport not configured; skipping html email");
+    return;
+  }
+
+  const text = html.replace(/<[^>]*>/g, "");
+  const mailOptions = {
+    from: process.env.SMTP_FROM || user,
+    to,
+    subject,
+    text,
+    html,
+  };
+
+  try {
+    await transporter.sendMail(mailOptions);
+  } catch (err) {
+    console.error("Failed to send html email", err);
+  }
+}
+
 export async function sendWireInstructionsEmail(to: string, order: Order) {
   if (!transporter) {
     console.warn("Email transport not configured; skipping wire instructions email");

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -11,6 +11,7 @@ import {
   sendProductQuestionEmail,
   sendAdminAlertEmail,
   sendAdminUserEmail,
+  sendHtmlEmail,
   sendSuspensionEmail,
   sendWireInstructionsEmail,
   sendWireReminderEmail,
@@ -22,6 +23,7 @@ import {
   insertOrderItemSchema,
   insertSellerApplicationSchema,
   insertSupportTicketSchema,
+  insertEmailTemplateSchema,
   insertOfferSchema,
   offers as offersTable,
   orders as ordersTable,
@@ -838,6 +840,73 @@ export async function registerRoutes(app: Express): Promise<Server> {
       }
     },
   );
+
+  app.get("/api/admin/email-templates", isAuthenticated, isAdmin, async (_req, res) => {
+    try {
+      const templates = await storage.getEmailTemplates();
+      res.json(templates);
+    } catch (error) {
+      handleApiError(res, error);
+    }
+  });
+
+  app.post("/api/admin/email-templates", isAuthenticated, isAdmin, async (req, res) => {
+    try {
+      const data = insertEmailTemplateSchema.parse(req.body);
+      const template = await storage.createEmailTemplate(data);
+      res.status(201).json(template);
+    } catch (error) {
+      handleApiError(res, error);
+    }
+  });
+
+  app.put("/api/admin/email-templates/:id", isAuthenticated, isAdmin, async (req, res) => {
+    try {
+      const id = parseInt(req.params.id, 10);
+      if (Number.isNaN(id)) return res.status(400).json({ message: "Invalid template ID" });
+      const template = await storage.updateEmailTemplate(id, req.body);
+      if (!template) return res.status(404).json({ message: "Template not found" });
+      res.json(template);
+    } catch (error) {
+      handleApiError(res, error);
+    }
+  });
+
+  app.delete("/api/admin/email-templates/:id", isAuthenticated, isAdmin, async (req, res) => {
+    try {
+      const id = parseInt(req.params.id, 10);
+      if (Number.isNaN(id)) return res.status(400).json({ message: "Invalid template ID" });
+      await storage.deleteEmailTemplate(id);
+      res.sendStatus(204);
+    } catch (error) {
+      handleApiError(res, error);
+    }
+  });
+
+  app.post("/api/admin/email-templates/:id/send", isAuthenticated, isAdmin, async (req, res) => {
+    try {
+      const id = parseInt(req.params.id, 10);
+      const group = req.body.group as string;
+      if (Number.isNaN(id) || (group !== "buyers" && group !== "sellers")) {
+        return res.status(400).json({ message: "Invalid parameters" });
+      }
+      const template = await storage.getEmailTemplate(id);
+      if (!template) return res.status(404).json({ message: "Template not found" });
+      const users = await storage.getUsers();
+      const targets = users.filter(u => u.role === (group === "buyers" ? "buyer" : "seller"));
+      for (const u of targets) {
+        const html = template.body
+          .replace(/\[first_name\]/gi, u.firstName)
+          .replace(/\[last_name\]/gi, u.lastName)
+          .replace(/\[name\]/gi, `${u.firstName} ${u.lastName}`)
+          .replace(/\[company\]/gi, u.company || "");
+        await sendHtmlEmail(u.email, template.subject, html);
+      }
+      res.sendStatus(204);
+    } catch (error) {
+      handleApiError(res, error);
+    }
+  });
 
   app.get("/api/admin/billing", isAuthenticated, isAdmin, async (_req, res) => {
     try {

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -11,7 +11,8 @@ import {
   productQuestions, ProductQuestion, InsertProductQuestion,
   offers, Offer, InsertOffer,
   supportTickets, SupportTicket, InsertSupportTicket,
-  notifications, Notification, InsertNotification
+  notifications, Notification, InsertNotification,
+  emailTemplates, EmailTemplate, InsertEmailTemplate
 } from "@shared/schema";
 import session from "express-session";
 import { db, pool } from "./db";
@@ -110,6 +111,13 @@ export interface IStorage {
   createSupportTicket(ticket: InsertSupportTicket): Promise<SupportTicket>;
   respondToSupportTicket(id: number, response: string): Promise<SupportTicket | undefined>;
   updateSupportTicketStatus(id: number, status: string): Promise<SupportTicket | undefined>;
+
+  // Email template methods
+  getEmailTemplates(): Promise<EmailTemplate[]>;
+  getEmailTemplate(id: number): Promise<EmailTemplate | undefined>;
+  createEmailTemplate(t: InsertEmailTemplate): Promise<EmailTemplate>;
+  updateEmailTemplate(id: number, t: Partial<EmailTemplate>): Promise<EmailTemplate | undefined>;
+  deleteEmailTemplate(id: number): Promise<void>;
 
   // Cart methods
   getCart(userId: number): Promise<Cart | undefined>;
@@ -724,6 +732,30 @@ export class DatabaseStorage implements IStorage {
         ORDER BY o.created_at DESC`
     );
     return result.rows;
+  }
+
+  // Email template methods
+  async getEmailTemplates(): Promise<EmailTemplate[]> {
+    return await db.select().from(emailTemplates).orderBy(desc(emailTemplates.createdAt));
+  }
+
+  async getEmailTemplate(id: number): Promise<EmailTemplate | undefined> {
+    const [t] = await db.select().from(emailTemplates).where(eq(emailTemplates.id, id));
+    return t;
+  }
+
+  async createEmailTemplate(t: InsertEmailTemplate): Promise<EmailTemplate> {
+    const [et] = await db.insert(emailTemplates).values(t).returning();
+    return et;
+  }
+
+  async updateEmailTemplate(id: number, t: Partial<EmailTemplate>): Promise<EmailTemplate | undefined> {
+    const [et] = await db.update(emailTemplates).set(t).where(eq(emailTemplates.id, id)).returning();
+    return et;
+  }
+
+  async deleteEmailTemplate(id: number): Promise<void> {
+    await db.delete(emailTemplates).where(eq(emailTemplates.id, id));
   }
 
   // Cart methods

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -390,6 +390,20 @@ export const insertSupportTicketMessageSchema = createInsertSchema(supportTicket
   createdAt: true,
 });
 
+// Saved email templates for admin communications
+export const emailTemplates = pgTable("email_templates", {
+  id: serial("id").primaryKey(),
+  name: text("name").notNull(),
+  subject: text("subject").notNull(),
+  body: text("body").notNull(),
+  createdAt: timestamp("created_at").defaultNow(),
+});
+
+export const insertEmailTemplateSchema = createInsertSchema(emailTemplates).omit({
+  id: true,
+  createdAt: true,
+});
+
 // In-app notifications for users
 export const notifications = pgTable("notifications", {
   id: serial("id").primaryKey(),
@@ -453,6 +467,9 @@ export type InsertSupportTicketMessage = z.infer<typeof insertSupportTicketMessa
 
 export type Notification = typeof notifications.$inferSelect;
 export type InsertNotification = z.infer<typeof insertNotificationSchema>;
+
+export type EmailTemplate = typeof emailTemplates.$inferSelect;
+export type InsertEmailTemplate = z.infer<typeof insertEmailTemplateSchema>;
 
 // Cart item interface for the frontend
 export interface CartItem {


### PR DESCRIPTION
## Summary
- support saved email templates in the DB
- expose CRUD API routes for templates
- send HTML emails with placeholder values to buyers or sellers
- implement React hooks and admin UI page
- link new page from dashboard and header

## Testing
- `npm run check` *(fails: Cannot find module 'wouter' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68642e0d33248330b7ab7bca6917c5ea