### PR TITLE
Hide buyer details from sellers

### DIFF
--- a/client/src/pages/seller/order-detail.tsx
+++ b/client/src/pages/seller/order-detail.tsx
@@ -122,20 +122,8 @@ export default function SellerOrderDetailPage() {
             <CardHeader>
               <CardTitle>Shipping Information</CardTitle>
             </CardHeader>
-            <CardContent className="space-y-1">
-              <p className="font-medium">{order.shippingDetails.name}</p>
-              <p>{order.shippingDetails.address}</p>
-              <p>
-                {order.shippingDetails.city}, {order.shippingDetails.state}{" "}
-                {order.shippingDetails.zipCode}
-              </p>
-              <p>{order.shippingDetails.country}</p>
-              {order.shippingDetails.phone && (
-                <p>Phone: {order.shippingDetails.phone}</p>
-              )}
-              {order.shippingDetails.email && (
-                <p>Email: {order.shippingDetails.email}</p>
-              )}
+            <CardContent>
+              Buyer contact information is hidden for privacy.
             </CardContent>
           </Card>
         )}

--- a/server/email.ts
+++ b/server/email.ts
@@ -238,12 +238,6 @@ export async function sendSellerOrderEmail(
   const sellerName = seller ? `${seller.firstName} ${seller.lastName}`.trim() : "";
 
   const shipping = order.shippingDetails as Record<string, any> | undefined;
-  const shippingLines = shipping
-    ? [`${shipping.name}`, `${shipping.address}`, `${shipping.city}, ${shipping.state} ${shipping.zipCode}`, `${shipping.country}`, shipping.phone ? `Phone: ${shipping.phone}` : null]
-        .filter(Boolean)
-        .map((l) => `<div>${l}</div>`)
-        .join("")
-    : "";
 
   const shippingMethod =
     order.shippingChoice === "buyer"
@@ -295,7 +289,6 @@ export async function sendSellerOrderEmail(
             </tbody>
           </table>
 
-          ${shippingLines ? `<div style="margin-top:20px;"><strong>Ship To:</strong>${shippingLines}</div>` : ""}
           <p style="margin-top:10px;">Shipping Method: ${shippingMethod}</p>
 
           <p style="margin-top:30px;">Order #: <strong>${order.code}</strong></p>


### PR DESCRIPTION
## Summary
- hide shipping details when sellers fetch orders
- redact contact info from seller order emails
- don't show buyer shipping details on seller order page

## Testing
- `npm run check` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68643cc4afcc8330ba1c0015d8bf2a71