### PR TITLE
Improve offer handling and cart integration

### DIFF
--- a/client/src/components/cart/cart-item.tsx
+++ b/client/src/components/cart/cart-item.tsx
@@ -22,12 +22,13 @@ export default function CartItem({ item }: CartItemProps) {
   const handleDecrease = () => {
     if (item.quantity <= item.minOrderQuantity) {
       // If reducing would go below MOQ, remove the item
-      removeFromCart(item.productId, item.variationKey);
+      removeFromCart(item.productId, item.variationKey, item.offerId);
     } else {
       updateQuantity(
         item.productId,
         item.variationKey,
-        item.quantity - item.orderMultiple
+        item.quantity - item.orderMultiple,
+        item.offerId
       );
     }
   };
@@ -37,14 +38,15 @@ export default function CartItem({ item }: CartItemProps) {
   };
 
   const commitInput = () => {
-    updateQuantity(item.productId, item.variationKey, inputQty);
+    updateQuantity(item.productId, item.variationKey, inputQty, item.offerId);
   };
 
   const handleIncrease = () => {
     updateQuantity(
       item.productId,
       item.variationKey,
-      item.quantity + item.orderMultiple
+      item.quantity + item.orderMultiple,
+      item.offerId
     );
   };
   
@@ -126,7 +128,7 @@ export default function CartItem({ item }: CartItemProps) {
               variant="ghost" 
               size="sm" 
               className="text-primary hover:text-primary-foreground hover:bg-primary font-medium flex items-center"
-              onClick={() => removeFromCart(item.productId, item.variationKey)}
+              onClick={() => removeFromCart(item.productId, item.variationKey, item.offerId)}
             >
               <Trash2 className="h-4 w-4 mr-1" />
               Remove

--- a/client/src/hooks/use-cart.tsx
+++ b/client/src/hooks/use-cart.tsx
@@ -1,5 +1,5 @@
 import { createContext, ReactNode, useContext, useState, useEffect } from "react";
-import { CartItem, Product } from "@shared/schema";
+import { CartItem, Product, Offer } from "@shared/schema";
 import { useToast } from "@/hooks/use-toast";
 import { useAuth } from "@/hooks/use-auth";
 import { addServiceFee } from "@/lib/utils";
@@ -9,13 +9,17 @@ interface CartContextType {
   addToCart: (
     product: Product,
     quantity: number,
-    variations?: Record<string, string>
+    variations?: Record<string, string>,
+    priceOverride?: number,
+    offerQuantity?: number,
+    offerId?: number
   ) => void;
-  removeFromCart: (productId: number, variationKey?: string) => void;
+  removeFromCart: (productId: number, variationKey?: string, offerId?: number) => void;
   updateQuantity: (
     productId: number,
     variationKey: string | undefined,
-    quantity: number
+    quantity: number,
+    offerId?: number
   ) => void;
   clearCart: () => void;
   cartTotal: number;
@@ -61,10 +65,43 @@ export function CartProvider({ children }: { children: ReactNode }) {
     localStorage.setItem(CART_STORAGE_KEY, JSON.stringify(items));
   }, [items]);
 
+  useEffect(() => {
+    async function loadAcceptedOffers() {
+      if (!user || user.role !== "buyer") return;
+      try {
+        const res = await fetch("/api/offers?status=accepted", {
+          credentials: "include",
+        });
+        if (!res.ok) return;
+        const offers: Offer[] = await res.json();
+        for (const o of offers) {
+          if (items.some((it) => it.offerId === o.id)) continue;
+          const prodRes = await fetch(`/api/products/${o.productId}`);
+          if (!prodRes.ok) continue;
+          const product = await prodRes.json();
+          addToCart(
+            product,
+            o.quantity,
+            o.selectedVariations ?? {},
+            o.price,
+            o.quantity,
+            o.id
+          );
+        }
+      } catch {
+        /* ignore */
+      }
+    }
+    loadAcceptedOffers();
+  }, [user]);
+
   const addToCart = (
     product: Product,
     quantity: number,
-    variations: Record<string, string> = {}
+    variations: Record<string, string> = {},
+    priceOverride?: number,
+    offerQuantity?: number,
+    offerId?: number
   ) => {
     if (quantity <= 0) return;
 
@@ -94,6 +131,15 @@ export function CartProvider({ children }: { children: ReactNode }) {
         ? product.variationStocks[varKey]
         : product.availableUnits;
 
+    if (offerQuantity !== undefined && quantity > offerQuantity) {
+      toast({
+        title: "Offer limit",
+        description: `Only ${offerQuantity} units are available at the agreed price`,
+        variant: "destructive",
+      });
+      quantity = offerQuantity;
+    }
+
     // Check if we have enough inventory
     if (quantity > availableUnits) {
       toast({
@@ -105,7 +151,9 @@ export function CartProvider({ children }: { children: ReactNode }) {
     }
 
     const basePrice =
-      product.variationPrices && product.variationPrices[varKey] !== undefined
+      priceOverride !== undefined
+        ? priceOverride
+        : product.variationPrices && product.variationPrices[varKey] !== undefined
         ? product.variationPrices[varKey]
         : product.price;
     const priceWithFee =
@@ -115,7 +163,10 @@ export function CartProvider({ children }: { children: ReactNode }) {
 
       setItems(prevItems => {
         const existingItemIndex = prevItems.findIndex(
-          item => item.productId === product.id && item.variationKey === varKey
+          item =>
+            item.productId === product.id &&
+            item.variationKey === varKey &&
+            item.offerId === offerId
         );
       
       if (existingItemIndex >= 0) {
@@ -133,9 +184,20 @@ export function CartProvider({ children }: { children: ReactNode }) {
           return prevItems;
         }
         
+        let finalQuantity = newQuantity;
+        const limit = updatedItems[existingItemIndex].offerQuantity;
+        if (limit !== undefined && newQuantity > limit) {
+          toast({
+            title: "Offer limit",
+            description: `Only ${limit} units are available at the agreed price`,
+            variant: "destructive",
+          });
+          finalQuantity = limit;
+        }
+
         updatedItems[existingItemIndex] = {
           ...updatedItems[existingItemIndex],
-          quantity: newQuantity
+          quantity: finalQuantity
         };
         
         return updatedItems;
@@ -153,7 +215,9 @@ export function CartProvider({ children }: { children: ReactNode }) {
             orderMultiple: product.orderMultiple,
             availableUnits,
             selectedVariations: variations,
-            variationKey: varKey
+            variationKey: varKey,
+            offerId,
+            offerQuantity
           }
         ];
       }
@@ -169,10 +233,15 @@ export function CartProvider({ children }: { children: ReactNode }) {
     setIsCartOpen(true);
   };
 
-  const removeFromCart = (productId: number, variationKey = "") => {
+  const removeFromCart = (productId: number, variationKey = "", offerId?: number) => {
     setItems(prevItems =>
       prevItems.filter(
-        item => !(item.productId === productId && (item.variationKey ?? "") === variationKey)
+        item =>
+          !(
+            item.productId === productId &&
+            (item.variationKey ?? "") === variationKey &&
+            (offerId === undefined || item.offerId === offerId)
+          )
       )
     );
     
@@ -185,16 +254,21 @@ export function CartProvider({ children }: { children: ReactNode }) {
   const updateQuantity = (
     productId: number,
     variationKey: string | undefined,
-    quantity: number
+    quantity: number,
+    offerId?: number
   ) => {
     if (quantity <= 0) {
-      removeFromCart(productId, variationKey);
+      removeFromCart(productId, variationKey, offerId);
       return;
     }
 
     setItems(prevItems => {
       return prevItems.map(item => {
-        if (item.productId === productId && (item.variationKey ?? "") === (variationKey ?? "")) {
+        if (
+          item.productId === productId &&
+          (item.variationKey ?? "") === (variationKey ?? "") &&
+          (offerId === undefined || item.offerId === offerId)
+        ) {
           // Check if quantity meets MOQ
           if (quantity < item.minOrderQuantity) {
             toast({
@@ -224,7 +298,16 @@ export function CartProvider({ children }: { children: ReactNode }) {
             });
             return item;
           }
-          
+
+          if (item.offerQuantity !== undefined && quantity > item.offerQuantity) {
+            toast({
+              title: "Offer limit",
+              description: `Only ${item.offerQuantity} units are available at the agreed price`,
+              variant: "destructive",
+            });
+            return item;
+          }
+
           return { ...item, quantity };
         }
         return item;

--- a/client/src/pages/buyer/offers.tsx
+++ b/client/src/pages/buyer/offers.tsx
@@ -1,45 +1,126 @@
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useMutation } from "@tanstack/react-query";
 import { Offer } from "@shared/schema";
 import Header from "@/components/layout/header";
 import Footer from "@/components/layout/footer";
 import { formatCurrency, SERVICE_FEE_RATE } from "@/lib/utils";
+import { apiRequest, queryClient } from "@/lib/queryClient";
+import { useToast } from "@/hooks/use-toast";
+import { useCart } from "@/hooks/use-cart";
+import { Button } from "@/components/ui/button";
 
 export default function BuyerOffersPage() {
   type OfferWithProduct = Offer & { productTitle: string };
 
-  const { data: offers = [] } = useQuery<OfferWithProduct[]>({
+  const { data: offers = [], isLoading } = useQuery<OfferWithProduct[]>({
     queryKey: ["/api/offers"],
   });
+
+  const { toast } = useToast();
+  const { addToCart, items } = useCart();
+
+  const acceptCounter = useMutation({
+    mutationFn: (id: number) =>
+      apiRequest("POST", `/api/offers/${id}/accept-counter`).then((r) => r.json()),
+    onSuccess: () => {
+      toast({ title: "Offer accepted" });
+      queryClient.invalidateQueries({ queryKey: ["/api/offers"] });
+    },
+    onError: (err: Error) =>
+      toast({ title: "Failed", description: err.message, variant: "destructive" }),
+  });
+
+  async function handleAddToCart(o: OfferWithProduct) {
+    try {
+      const res = await fetch(`/api/products/${o.productId}`);
+      if (!res.ok) return;
+      const product = await res.json();
+      addToCart(
+        product,
+        o.quantity,
+        o.selectedVariations ?? {},
+        o.price,
+        o.quantity,
+        o.id
+      );
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  const pending = offers.filter((o) => o.status === "pending");
+  const accepted = offers.filter((o) => o.status === "accepted");
+  const rejected = offers.filter((o) => o.status === "rejected");
+  const countered = offers.filter((o) => o.status === "countered");
 
   return (
     <>
       <Header />
       <main className="max-w-7xl mx-auto px-4 py-8">
         <h1 className="text-3xl font-bold mb-6">My Offers</h1>
-        <div className="space-y-4">
-          {offers.map((o) => (
-            <div key={o.id} className="border p-4 rounded">
-              <div className="flex justify-between">
-                <div>
-                  <p className="font-medium">{o.productTitle}</p>
-                  {o.selectedVariations && (
-                    <p className="text-sm text-gray-500">
-                      {Object.entries(o.selectedVariations)
-                        .map(([k, v]) => `${k}: ${v}`)
-                        .join(", ")}
-                    </p>
-                  )}
-                  <p className="text-sm">Quantity: {o.quantity}</p>
-                </div>
-                <div className="text-right">
-                  <p>{formatCurrency(o.price * (1 - SERVICE_FEE_RATE))}</p>
-                  <p className="text-xs text-gray-500">after 3.5% commission</p>
-                  <span className="text-xs capitalize">{o.status}</span>
-                </div>
-              </div>
-            </div>
-          ))}
-          {offers.length === 0 && <p>No offers yet.</p>}
+        <div className="space-y-8">
+          {isLoading ? (
+            <p>Loading...</p>
+          ) : (
+            <>
+              {[{
+                label: "Pending",
+                list: pending,
+              },
+              {
+                label: "Countered",
+                list: countered,
+              },
+              {
+                label: "Accepted",
+                list: accepted,
+              },
+              {
+                label: "Rejected",
+                list: rejected,
+              }].map(
+                ({ label, list }) => (
+                  <div key={label} className="space-y-2">
+                    <h2 className="font-medium text-lg">{label}</h2>
+                    {list.length === 0 ? (
+                      <p className="text-sm text-gray-500">None</p>
+                    ) : (
+                      list.map((o) => (
+                        <div key={o.id} className="border p-4 rounded space-y-2">
+                          <div className="flex justify-between">
+                            <div>
+                              <p className="font-medium">{o.productTitle}</p>
+                              {o.selectedVariations && (
+                                <p className="text-sm text-gray-500">
+                                  {Object.entries(o.selectedVariations)
+                                    .map(([k, v]) => `${k}: ${v}`)
+                                    .join(", ")}
+                                </p>
+                              )}
+                              <p className="text-sm">Quantity: {o.quantity}</p>
+                            </div>
+                            <div className="text-right space-y-1">
+                              <p>{formatCurrency(o.price * (1 + SERVICE_FEE_RATE))}</p>
+                              <span className="text-xs capitalize">{o.status}</span>
+                            </div>
+                          </div>
+                          {label === "Countered" && (
+                            <Button size="sm" onClick={() => acceptCounter.mutate(o.id)}>
+                              Accept Counter
+                            </Button>
+                          )}
+                          {label === "Accepted" && (
+                            <Button size="sm" onClick={() => handleAddToCart(o)} disabled={items.some(it => it.offerId === o.id)}>
+                              {items.some(it => it.offerId === o.id) ? "In Cart" : "Add to Cart"}
+                            </Button>
+                          )}
+                        </div>
+                      ))
+                    )}
+                  </div>
+                )
+              )}
+            </>
+          )}
         </div>
       </main>
       <Footer />

--- a/client/src/pages/seller/offers.tsx
+++ b/client/src/pages/seller/offers.tsx
@@ -89,9 +89,6 @@ export default function SellerOffersPage() {
                 <p className="text-sm">Quantity: {o.quantity}</p>
                 <p className="text-sm">Price: {formatCurrency(o.price)}</p>
                 <span className="text-xs capitalize">Status: {o.status}</span>
-                {o.status === "accepted" && o.orderId && (
-                  <p className="text-xs">Order #{o.orderId}</p>
-                )}
               </div>
               {o.status === "pending" && (
                 <div className="space-x-2 flex items-start">

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -36,6 +36,8 @@ import { generateOrderCode } from "./orderCode";
 import { ZodError } from "zod";
 import { containsContactInfo } from "./contactFilter";
 
+const SERVICE_FEE_RATE = 0.035;
+
 async function fetchTrackingStatus(trackingNumber: string): Promise<string | undefined> {
   try {
     const apiKey = process.env.TRACKTRY_API_KEY;
@@ -216,6 +218,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
       const offerData = insertOfferSchema.parse({
         ...req.body,
+        price: req.body.price * (1 - SERVICE_FEE_RATE),
         productId: id,
         buyerId: user.id,
         sellerId: product.sellerId,
@@ -1250,6 +1253,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       const filter: any = {};
       if (user.role === 'buyer') filter.buyerId = user.id;
       else if (user.role === 'seller') filter.sellerId = user.id;
+      if (req.query.status) filter.status = String(req.query.status);
       const offers = await storage.getOffers(filter);
       res.json(offers);
     } catch (error) {
@@ -1276,86 +1280,16 @@ export async function registerRoutes(app: Express): Promise<Server> {
         return res.status(400).json({ message: "Offer already processed" });
       }
 
-      // Create order based on offer
-      const orderData = insertOrderSchema.parse({
-        buyerId: offer.buyerId,
-        sellerId: offer.sellerId,
-        totalAmount: offer.price * offer.quantity,
-      });
-
-      const invoiceItems: {
-        title: string;
-        quantity: number;
-        unitPrice: number;
-        totalPrice: number;
-        selectedVariations?: Record<string, string>;
-        image?: string;
-      }[] = [];
-
-      const order = await db.transaction(async (tx) => {
-        const [createdOrder] = await tx.insert(ordersTable).values(orderData).returning();
-        const code = generateOrderCode(createdOrder.id);
-        const [withCode] = await tx.update(ordersTable).set({ code }).where(eq(ordersTable.id, createdOrder.id)).returning();
-
-        const orderItemData = insertOrderItemSchema.parse({
-          orderId: createdOrder.id,
-          productId: offer.productId,
-          quantity: offer.quantity,
-          unitPrice: offer.price,
-          totalPrice: offer.price * offer.quantity,
-          selectedVariations: offer.selectedVariations ?? null,
-        });
-
-        await tx.insert(orderItemsTable).values(orderItemData);
-
-        const [product] = await tx
-          .select()
-          .from(productsTable)
-          .where(eq(productsTable.id, offer.productId));
-        if (product) {
-          const updateData: any = {
-            availableUnits: product.availableUnits - offer.quantity,
-          };
-          if (offer.selectedVariations) {
-            const varKey = JSON.stringify(offer.selectedVariations);
-            const stocks = (product.variationStocks || {}) as Record<string, number>;
-            if (stocks[varKey] !== undefined) {
-              stocks[varKey] = stocks[varKey] - offer.quantity;
-              updateData.variationStocks = stocks;
-            }
-          }
-          await tx
-            .update(productsTable)
-            .set(updateData)
-            .where(eq(productsTable.id, offer.productId));
-          invoiceItems.push({
-            title: product.title,
-            quantity: offer.quantity,
-            unitPrice: offer.price,
-            totalPrice: offer.price * offer.quantity,
-            selectedVariations: offer.selectedVariations ?? undefined,
-            image: product.images?.[0],
-          });
-        }
-
-        return withCode;
-      });
-
-      await storage.updateOffer(offerId, { status: 'accepted', orderId: order.id });
+      const updated = await storage.updateOffer(offerId, { status: 'accepted' });
 
       await storage.createNotification({
         userId: offer.buyerId,
         type: 'offer',
-        content: `Your offer for order #${order.code} was accepted`,
-        link: `/buyer/orders/${order.id}`,
+        content: `Your offer for ${offer.quantity} units was accepted`,
+        link: `/buyer/offers`,
       });
 
-      const buyer = await storage.getUser(offer.buyerId);
-      if (buyer) {
-        sendInvoiceEmail(buyer.email, order, invoiceItems, buyer).catch(console.error);
-      }
-
-      res.json(order);
+      res.json(updated);
     } catch (error) {
       handleApiError(res, error);
     }
@@ -1402,6 +1336,39 @@ export async function registerRoutes(app: Express): Promise<Server> {
         type: 'offer',
         content: `Counter offer for ${product.title}`,
         link: `/buyer/offers`,
+      });
+
+      res.json(updated);
+    } catch (error) {
+      handleApiError(res, error);
+    }
+  });
+
+  app.post("/api/offers/:id/accept-counter", isAuthenticated, async (req, res) => {
+    try {
+      const offerId = parseInt(req.params.id, 10);
+      if (Number.isNaN(offerId)) {
+        return res.status(400).json({ message: "Invalid offer ID" });
+      }
+      const user = req.user as Express.User;
+      const offer = await storage.getOffer(offerId);
+      if (!offer) {
+        return res.status(404).json({ message: "Offer not found" });
+      }
+      if (user.role !== 'buyer' || offer.buyerId !== user.id) {
+        return res.status(403).json({ message: "Forbidden" });
+      }
+      if (offer.status !== 'countered') {
+        return res.status(400).json({ message: 'Offer is not countered' });
+      }
+
+      const updated = await storage.updateOffer(offerId, { status: 'accepted' });
+
+      await storage.createNotification({
+        userId: offer.sellerId,
+        type: 'offer',
+        content: `Counter offer accepted by buyer`,
+        link: `/seller/offers`,
       });
 
       res.json(updated);

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -493,6 +493,8 @@ export interface CartItem {
   minOrderQuantity: number;
   orderMultiple: number;
   availableUnits: number;
+  offerId?: number;
+  offerQuantity?: number;
   selectedVariations?: Record<string, string>;
   variationKey?: string;
 }


### PR DESCRIPTION
## Summary
- persist offer discounts when stored in cart
- load accepted offers into cart automatically
- show buyer offers grouped by status and limit discount quantity
- subtract service fee from offers before sellers see them
- allow filtering offers by status

## Testing
- `npm run check` *(fails: cannot install packages)*

------
https://chatgpt.com/codex/tasks/task_e_68643d7bc90883309fa997c1dcef8ff0