### PR TITLE
Adjust seller order totals

### DIFF
--- a/client/src/lib/utils.ts
+++ b/client/src/lib/utils.ts
@@ -7,6 +7,11 @@ export function cn(...inputs: ClassValue[]) {
 
 export const SERVICE_FEE_RATE = 0.035;
 
+// Remove the service fee and round to the nearest cent
+export function removeServiceFee(priceWithFee: number): number {
+  return Math.round(priceWithFee * (1 - SERVICE_FEE_RATE) * 100) / 100;
+}
+
 // Round a number up to the nearest cent
 export function roundUpToCent(amount: number): number {
   return Math.ceil(amount * 100) / 100;

--- a/client/src/pages/seller/order-detail.tsx
+++ b/client/src/pages/seller/order-detail.tsx
@@ -13,7 +13,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { CalendarIcon, ArrowLeft } from "lucide-react";
 import OrderStatus from "@/components/buyer/order-status";
-import { formatCurrency, formatDate } from "@/lib/utils";
+import { formatCurrency, formatDate, removeServiceFee } from "@/lib/utils";
 
 export default function SellerOrderDetailPage() {
   const { id } = useParams();
@@ -100,9 +100,9 @@ export default function SellerOrderDetailPage() {
                     </div>
                     <div className="text-right text-sm space-y-1">
                       <p>Qty: {item.quantity}</p>
-                      <p>{formatCurrency(item.unitPrice)} each</p>
+                      <p>{formatCurrency(removeServiceFee(item.unitPrice))} each</p>
                       <p className="font-medium">
-                        {formatCurrency(item.totalPrice)}
+                        {formatCurrency(removeServiceFee(item.totalPrice))}
                       </p>
                     </div>
                   </li>
@@ -112,7 +112,7 @@ export default function SellerOrderDetailPage() {
 
             <div className="border-t pt-4 flex justify-between font-medium">
               <span>Total</span>
-              <span>{formatCurrency(order.totalAmount)}</span>
+              <span>{formatCurrency(removeServiceFee(order.totalAmount))}</span>
             </div>
           </CardContent>
         </Card>


### PR DESCRIPTION
## Summary
- show listing price in seller order details instead of buyer price
- add `removeServiceFee` helper for reversing the buyer upcharge

## Testing
- `npm run check` *(fails: cannot download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686441c12ae8833092702938beda0e9d