### PR TITLE
Allow shipping per product

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -439,22 +439,21 @@ export async function registerRoutes(app: Express): Promise<Server> {
       }
 
       let totalAmount = sellerTotal;
-      if (
-        orderData.shippingChoice === "seller" &&
-        req.body.items &&
-        Array.isArray(req.body.items) &&
-        req.body.items.length > 0
-      ) {
-        const [product] = await db
-          .select()
-          .from(productsTable)
-          .where(eq(productsTable.id, req.body.items[0].productId));
-        if (
-          product &&
-          product.shippingResponsibility === "seller_fee" &&
-          product.shippingFee
-        ) {
-          totalAmount += Number(product.shippingFee);
+      if (req.body.items && Array.isArray(req.body.items)) {
+        for (const item of req.body.items) {
+          if (item.shippingChoice === "seller") {
+            const [product] = await db
+              .select()
+              .from(productsTable)
+              .where(eq(productsTable.id, item.productId));
+            if (
+              product &&
+              product.shippingResponsibility === "seller_fee" &&
+              product.shippingFee
+            ) {
+              totalAmount += Number(product.shippingFee);
+            }
+          }
         }
       }
       orderData.totalAmount = totalAmount;

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -341,6 +341,8 @@ export class DatabaseStorage implements IStorage {
         unitPrice: orderItems.unitPrice,
         totalPrice: orderItems.totalPrice,
         selectedVariations: orderItems.selectedVariations,
+        shippingChoice: orderItems.shippingChoice,
+        shippingCarrier: orderItems.shippingCarrier,
         productTitle: products.title,
         productImages: products.images,
       })

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -222,6 +222,8 @@ export const orderItems = pgTable("order_items", {
   unitPrice: doublePrecision("unit_price").notNull(),
   totalPrice: doublePrecision("total_price").notNull(),
   selectedVariations: jsonb("selected_variations"),
+  shippingChoice: text("shipping_choice"),
+  shippingCarrier: text("shipping_carrier"),
 });
 
 export const orderItemsRelations = relations(orderItems, ({ one }) => ({
@@ -241,6 +243,8 @@ export const insertOrderItemSchema = createInsertSchema(orderItems)
   })
   .extend({
     selectedVariations: z.record(z.string()).optional().nullable(),
+    shippingChoice: z.string().optional(),
+    shippingCarrier: z.string().optional(),
   });
 
 // Seller application schema


### PR DESCRIPTION
## Summary
- support recording shipping choice and carrier for each order item
- aggregate shipping fees for each item on order creation
- ask shipping questions for every product during checkout

## Testing
- `bash test_with_existing_user.sh` *(fails: see logs)*
- `npm run check` *(fails: see logs)*

------
https://chatgpt.com/codex/tasks/task_e_68644f2220ec833089fd207a24aadc30