### PR TITLE
Enable seller to view shipping address when shipping themselves

### DIFF
--- a/client/src/pages/seller/order-detail.tsx
+++ b/client/src/pages/seller/order-detail.tsx
@@ -123,7 +123,21 @@ export default function SellerOrderDetailPage() {
               <CardTitle>Shipping Information</CardTitle>
             </CardHeader>
             <CardContent>
-              Buyer contact information is hidden for privacy.
+              {order.shippingChoice === "seller" ? (
+                <>
+                  <p className="font-medium">{order.shippingDetails.name}</p>
+                  <p>{order.shippingDetails.address}</p>
+                  <p>
+                    {order.shippingDetails.city}, {order.shippingDetails.state}{" "}
+                    {order.shippingDetails.zipCode}
+                  </p>
+                  <p>{order.shippingDetails.country}</p>
+                  {order.shippingDetails.phone && <p>{order.shippingDetails.phone}</p>}
+                  {order.shippingDetails.email && <p>{order.shippingDetails.email}</p>}
+                </>
+              ) : (
+                <>Buyer contact information is hidden for privacy.</>
+              )}
             </CardContent>
           </Card>
         )}

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -333,6 +333,9 @@ export async function registerRoutes(app: Express): Promise<Server> {
           const previewImage = items[0]?.productImages[0] || null;
           const orderWithItems = { ...o, previewImage, items };
           if (user.role === "seller") {
+            if (o.shippingChoice === "seller") {
+              return orderWithItems;
+            }
             const { shippingDetails, ...rest } = orderWithItems as any;
             return rest;
           }
@@ -366,8 +369,12 @@ export async function registerRoutes(app: Express): Promise<Server> {
       // Get order items with product info
       const orderItems = await storage.getOrderItemsWithProducts(id);
       if (user.role === "seller") {
-        const { shippingDetails, ...rest } = order as any;
-        res.json({ ...rest, items: orderItems });
+        if (order.shippingChoice === "seller") {
+          res.json({ ...order, items: orderItems });
+        } else {
+          const { shippingDetails, ...rest } = order as any;
+          res.json({ ...rest, items: orderItems });
+        }
       } else {
         res.json({ ...order, items: orderItems });
       }


### PR DESCRIPTION
## Summary
- return shipping details to sellers when `shippingChoice` is `seller`
- show buyer shipping info on seller dashboard in that case

## Testing
- `npm run check` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68645a04f7008330a8218d4aa609c51e