### PR TITLE
Restrict seller status update workflow

### DIFF
--- a/client/src/pages/seller/dashboard.tsx
+++ b/client/src/pages/seller/dashboard.tsx
@@ -268,13 +268,6 @@ export default function SellerDashboard() {
     setTrackingNum("");
   }
 
-  function handleMarkOutForDelivery(id: number) {
-    updateOrder.mutate({ id, update: { status: "out_for_delivery" } });
-  }
-
-  function handleMarkDelivered(id: number) {
-    updateOrder.mutate({ id, update: { status: "delivered" } });
-  }
 
   function handleCancelOrder(id: number) {
     if (window.confirm("Cancel this order?")) {

--- a/client/src/pages/seller/orders.tsx
+++ b/client/src/pages/seller/orders.tsx
@@ -96,13 +96,6 @@ export default function SellerOrdersPage() {
     setTrackingNum("");
   }
 
-  function handleMarkOutForDelivery(id: number) {
-    updateOrder.mutate({ id, update: { status: "out_for_delivery" } });
-  }
-
-  function handleMarkDelivered(id: number) {
-    updateOrder.mutate({ id, update: { status: "delivered" } });
-  }
 
   function handleCancelOrder(id: number) {
     if (window.confirm("Cancel this order?")) {
@@ -181,22 +174,6 @@ export default function SellerOrdersPage() {
                           onClick={() => handleMarkAsShipped(order.id)}
                         >
                           Mark as Shipped
-                        </Button>
-                        <Button
-                          size="sm"
-                          variant={order.status === "shipped" ? "default" : "outline"}
-                          disabled={order.status !== "shipped"}
-                          onClick={() => handleMarkOutForDelivery(order.id)}
-                        >
-                          Mark as Out for Delivery
-                        </Button>
-                        <Button
-                          size="sm"
-                          variant={order.status === "out_for_delivery" ? "default" : "outline"}
-                          disabled={order.status !== "out_for_delivery"}
-                          onClick={() => handleMarkDelivered(order.id)}
-                        >
-                          Mark as Delivered
                         </Button>
                       </div>
                     </div>


### PR DESCRIPTION
## Summary
- prevent sellers from setting orders to delivered or out for delivery
- add admin endpoint to mark orders delivered
- adjust seller dashboard and orders pages to only allow shipping

## Testing
- `npm run check` *(fails: Cannot find module '@vitejs/plugin-react' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6865560c36e08330ac558dc7ad404fba