### PR TITLE
Implement buyer-arranged shipping info flow

### DIFF
--- a/client/src/pages/buyer/order-detail.tsx
+++ b/client/src/pages/buyer/order-detail.tsx
@@ -175,33 +175,54 @@ export default function BuyerOrderDetailPage() {
         )}
 
         {order.shippingChoice === "buyer" && (
-          <Card>
-            <CardHeader>
-              <CardTitle>Shipping Label</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-2">
-              {order.shippingLabel ? (
-                <Button asChild>
-                  <a href={order.shippingLabel} download>
-                    Download Label
-                  </a>
-                </Button>
-              ) : (
-                <>
-                  <input
-                    type="file"
-                    accept="application/pdf,image/*"
-                    ref={fileInputRef}
-                    onChange={handleFileUpload}
-                    className="hidden"
-                  />
-                  <Button onClick={triggerUpload} disabled={uploading}>
-                    {uploading ? "Uploading..." : "Upload Label"}
+          <>
+            <Card className="mb-4">
+              <CardHeader>
+                <CardTitle>Package Details</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-1 text-sm">
+                {order.shippingPackage ? (
+                  <>
+                    <p>
+                      Dimensions: {order.shippingPackage.length} x {order.shippingPackage.width} x {order.shippingPackage.height}
+                    </p>
+                    <p>Weight: {order.shippingPackage.weight}</p>
+                    <p>Ship From: {order.shippingPackage.address}</p>
+                  </>
+                ) : (
+                  <p>Waiting for seller to provide shipping info...</p>
+                )}
+              </CardContent>
+            </Card>
+            <Card>
+              <CardHeader>
+                <CardTitle>Shipping Label</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-2">
+                {order.shippingLabel ? (
+                  <Button asChild>
+                    <a href={order.shippingLabel} download>
+                      Download Label
+                    </a>
                   </Button>
-                </>
-              )}
-            </CardContent>
-          </Card>
+                ) : (
+                  <>
+                    <input
+                      type="file"
+                      accept="application/pdf,image/*"
+                      ref={fileInputRef}
+                      onChange={handleFileUpload}
+                      className="hidden"
+                      disabled={!order.shippingPackage}
+                    />
+                    <Button onClick={triggerUpload} disabled={uploading || !order.shippingPackage}>
+                      {uploading ? "Uploading..." : "Upload Label"}
+                    </Button>
+                  </>
+                )}
+              </CardContent>
+            </Card>
+          </>
         )}
 
         {order.status === "awaiting_wire" && (

--- a/client/src/pages/buyer/orders.tsx
+++ b/client/src/pages/buyer/orders.tsx
@@ -234,7 +234,7 @@ export default function BuyerOrdersPage() {
                                 setUploadingId(order.id);
                                 fileInputRef.current?.click();
                               }}
-                              disabled={uploadingId === order.id}
+                              disabled={uploadingId === order.id || !order.shippingPackage}
                             >
                               {uploadingId === order.id ? "Uploading..." : "Upload Label"}
                             </Button>
@@ -316,7 +316,7 @@ export default function BuyerOrdersPage() {
                                   setUploadingId(order.id);
                                   fileInputRef.current?.click();
                                 }}
-                                disabled={uploadingId === order.id}
+                                disabled={uploadingId === order.id || !order.shippingPackage}
                               >
                                 {uploadingId === order.id ? "Uploading..." : "Upload Label"}
                               </Button>

--- a/client/src/pages/seller/order-detail.tsx
+++ b/client/src/pages/seller/order-detail.tsx
@@ -1,5 +1,6 @@
 import { Link, useParams } from "wouter";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useState } from "react";
 import { Order, OrderItem } from "@shared/schema";
 
 interface OrderItemWithProduct extends OrderItem {
@@ -11,6 +12,9 @@ import Header from "@/components/layout/header";
 import Footer from "@/components/layout/footer";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { apiRequest } from "@/lib/queryClient";
 import { CalendarIcon, ArrowLeft } from "lucide-react";
 import OrderStatus from "@/components/buyer/order-status";
 import {
@@ -28,6 +32,17 @@ export default function SellerOrderDetailPage() {
     queryKey: ["/api/orders/" + orderId],
     enabled: !Number.isNaN(orderId),
   });
+
+  const queryClient = useQueryClient();
+  const updateOrder = useMutation({
+    mutationFn: (data: any) =>
+      apiRequest("PUT", `/api/orders/${orderId}` , data).then((r) => r.json()),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["/api/orders/" + orderId] });
+    },
+  });
+
+  const [pkg, setPkg] = useState({ length: "", width: "", height: "", weight: "", address: "" });
 
   if (isLoading) {
     return (
@@ -148,22 +163,77 @@ export default function SellerOrderDetailPage() {
         )}
 
         {order.shippingChoice === "buyer" && (
-          <Card>
-            <CardHeader>
-              <CardTitle>Shipping Label</CardTitle>
-            </CardHeader>
-            <CardContent>
-              {order.shippingLabel ? (
-                <Button asChild>
-                  <a href={order.shippingLabel} download>
-                    Download Label
-                  </a>
-                </Button>
-              ) : (
-                <p>No label uploaded</p>
-              )}
-            </CardContent>
-          </Card>
+          <>
+            <Card className="mb-4">
+              <CardHeader>
+                <CardTitle>Package Details</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-2">
+                {order.shippingPackage ? (
+                  <div className="space-y-1 text-sm">
+                    <p>Dimensions: {order.shippingPackage.length} x {order.shippingPackage.width} x {order.shippingPackage.height}</p>
+                    <p>Weight: {order.shippingPackage.weight}</p>
+                    <p>Ship From: {order.shippingPackage.address}</p>
+                  </div>
+                ) : (
+                  <div className="space-y-2">
+                    <div className="flex gap-2">
+                      <Input
+                        placeholder="Length"
+                        value={pkg.length}
+                        onChange={(e) => setPkg({ ...pkg, length: e.target.value })}
+                      />
+                      <Input
+                        placeholder="Width"
+                        value={pkg.width}
+                        onChange={(e) => setPkg({ ...pkg, width: e.target.value })}
+                      />
+                      <Input
+                        placeholder="Height"
+                        value={pkg.height}
+                        onChange={(e) => setPkg({ ...pkg, height: e.target.value })}
+                      />
+                      <Input
+                        placeholder="Weight"
+                        value={pkg.weight}
+                        onChange={(e) => setPkg({ ...pkg, weight: e.target.value })}
+                      />
+                    </div>
+                    <div>
+                      <Input
+                        placeholder="Ship from address"
+                        value={pkg.address}
+                        onChange={(e) => setPkg({ ...pkg, address: e.target.value })}
+                      />
+                    </div>
+                    <Button
+                      onClick={() => updateOrder.mutate({ shippingPackage: pkg })}
+                      disabled={updateOrder.isPending}
+                    >
+                      {updateOrder.isPending ? "Saving..." : "Save"}
+                    </Button>
+                  </div>
+                )}
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle>Shipping Label</CardTitle>
+              </CardHeader>
+              <CardContent>
+                {order.shippingLabel ? (
+                  <Button asChild>
+                    <a href={order.shippingLabel} download>
+                      Download Label
+                    </a>
+                  </Button>
+                ) : (
+                  <p>No label uploaded</p>
+                )}
+              </CardContent>
+            </Card>
+          </>
         )}
       </main>
       <Footer />

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -178,6 +178,7 @@ export const orders = pgTable("orders", {
   shippingChoice: text("shipping_choice"),
   shippingCarrier: text("shipping_carrier"),
   shippingLabel: text("shipping_label"),
+  shippingPackage: jsonb("shipping_package"),
   buyerCharged: boolean("buyer_charged").default(false),
   sellerPaid: boolean("seller_paid").default(false),
   deliveredAt: timestamp("delivered_at"),
@@ -211,6 +212,7 @@ export const insertOrderSchema = createInsertSchema(orders)
     shippingChoice: z.string().optional(),
     shippingCarrier: z.string().optional(),
     shippingLabel: z.string().optional(),
+    shippingPackage: z.any().optional(),
   });
 
 // Order items schema


### PR DESCRIPTION
## Summary
- add `shippingPackage` field to order schema
- require sellers to input package info when buyer arranges shipping
- show package details to buyers and gate label upload until provided

## Testing
- `npm run check` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_6865558e8204833092a50327e093aef6