### PR TITLE
Add admin order management

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -41,6 +41,7 @@ import AdminUsers from "@/pages/admin/users";
 import AdminBillingPage from "@/pages/admin/billing";
 import AdminWireOrdersPage from "@/pages/admin/wire-orders";
 import AdminOrderDetailPage from "@/pages/admin/order-detail";
+import AdminOrdersPage from "@/pages/admin/orders";
 import AdminApplications from "@/pages/admin/applications";
 import HelpPage from "@/pages/help-page";
 import AdminTicketsPage from "@/pages/admin/tickets";
@@ -106,6 +107,7 @@ function Router() {
       <ProtectedRoute path="/admin/users" component={AdminUsers} allowedRoles={["admin"]} />
       <ProtectedRoute path="/admin/billing" component={AdminBillingPage} allowedRoles={["admin"]} />
       <ProtectedRoute path="/admin/wire-orders" component={AdminWireOrdersPage} allowedRoles={["admin"]} />
+      <ProtectedRoute path="/admin/orders" component={AdminOrdersPage} allowedRoles={["admin"]} />
       <ProtectedRoute path="/admin/orders/:id" component={AdminOrderDetailPage} allowedRoles={["admin"]} />
       <ProtectedRoute path="/admin/applications" component={AdminApplications} allowedRoles={["admin"]} />
       <ProtectedRoute path="/admin/featured" component={FeaturedProductsPage} allowedRoles={["admin"]} />

--- a/client/src/pages/admin/dashboard.tsx
+++ b/client/src/pages/admin/dashboard.tsx
@@ -165,6 +165,12 @@ export default function AdminDashboard() {
                 Wire Orders
               </Button>
             </Link>
+            <Link href="/admin/orders">
+              <Button variant="outline" className="flex items-center">
+                <Package className="mr-2 h-4 w-4" />
+                Orders
+              </Button>
+            </Link>
             <Link href="/admin/featured">
               <Button variant="outline" className="flex items-center">
                 <Star className="mr-2 h-4 w-4" />

--- a/client/src/pages/admin/order-detail.tsx
+++ b/client/src/pages/admin/order-detail.tsx
@@ -140,6 +140,25 @@ export default function AdminOrderDetailPage() {
           </Card>
         )}
 
+        <Card>
+          <CardHeader>
+            <CardTitle>Shipment Details</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-1">
+            <p>Shipping Choice: {order.shippingChoice || "-"}</p>
+            {order.shippingCarrier && <p>Carrier: {order.shippingCarrier}</p>}
+            {order.trackingNumber && <p>Tracking #: {order.trackingNumber}</p>}
+            {order.shippingLabel && (
+              <p>
+                Label: {" "}
+                <a href={order.shippingLabel} download className="text-primary underline">
+                  Download
+                </a>
+              </p>
+            )}
+          </CardContent>
+        </Card>
+
         {order.paymentDetails && (
           <Card>
             <CardHeader>

--- a/client/src/pages/admin/orders.tsx
+++ b/client/src/pages/admin/orders.tsx
@@ -1,0 +1,141 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { Link } from "wouter";
+import Header from "@/components/layout/header";
+import Footer from "@/components/layout/footer";
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+} from "@/components/ui/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from "@/components/ui/select";
+import { Button } from "@/components/ui/button";
+import { Loader2, ArrowLeft } from "lucide-react";
+import { apiRequest } from "@/lib/queryClient";
+import { formatCurrency, formatDate } from "@/lib/utils";
+import { Order } from "@shared/schema";
+import { useToast } from "@/hooks/use-toast";
+
+export default function AdminOrdersPage() {
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+  const { data: orders = [], isLoading } = useQuery<Order[]>({
+    queryKey: ["/api/orders"],
+  });
+
+  const { mutate: updateStatus } = useMutation({
+    mutationFn: (data: { id: number; status: string }) =>
+      apiRequest("PUT", `/api/orders/${data.id}`, { status: data.status }).then(r => r.json()),
+    onSuccess: () => {
+      toast({ title: "Order updated" });
+      queryClient.invalidateQueries({ queryKey: ["/api/orders"] });
+    },
+    onError: (err: Error) => {
+      toast({ title: "Update failed", description: err.message, variant: "destructive" });
+    },
+  });
+
+  return (
+    <>
+      <Header />
+      <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <div className="mb-6">
+          <Link href="/admin/dashboard">
+            <a className="text-primary hover:underline flex items-center">
+              <ArrowLeft className="h-4 w-4 mr-1" /> Back to Dashboard
+            </a>
+          </Link>
+        </div>
+        <Card>
+          <CardHeader>
+            <CardTitle>All Orders</CardTitle>
+            <CardDescription>Manage every order on the platform</CardDescription>
+          </CardHeader>
+          <CardContent>
+            {isLoading ? (
+              <div className="flex justify-center py-12">
+                <Loader2 className="h-8 w-8 animate-spin text-primary" />
+              </div>
+            ) : orders.length > 0 ? (
+              <div className="overflow-x-auto">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Order</TableHead>
+                      <TableHead>Buyer</TableHead>
+                      <TableHead>Seller</TableHead>
+                      <TableHead>Status</TableHead>
+                      <TableHead>Shipping</TableHead>
+                      <TableHead>Tracking #</TableHead>
+                      <TableHead>Label</TableHead>
+                      <TableHead className="text-right">Total</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {orders.map(o => (
+                      <TableRow key={o.id}>
+                        <TableCell>
+                          <Link href={`/admin/orders/${o.id}`} className="text-primary hover:underline">
+                            #{o.code}
+                          </Link>
+                          <div className="text-xs text-gray-500">{formatDate(o.createdAt)}</div>
+                        </TableCell>
+                        <TableCell>#{o.buyerId}</TableCell>
+                        <TableCell>#{o.sellerId}</TableCell>
+                        <TableCell>
+                          <Select value={o.status} onValueChange={s => updateStatus({ id: o.id, status: s })}>
+                            <SelectTrigger className="w-[160px]">
+                              <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                              <SelectItem value="awaiting_wire">Awaiting Wire</SelectItem>
+                              <SelectItem value="ordered">Ordered</SelectItem>
+                              <SelectItem value="shipped">Shipped</SelectItem>
+                              <SelectItem value="out_for_delivery">Out for Delivery</SelectItem>
+                              <SelectItem value="delivered">Delivered</SelectItem>
+                              <SelectItem value="cancelled">Cancelled</SelectItem>
+                            </SelectContent>
+                          </Select>
+                        </TableCell>
+                        <TableCell>{o.shippingChoice || "-"}</TableCell>
+                        <TableCell>{o.trackingNumber || "-"}</TableCell>
+                        <TableCell>
+                          {o.shippingLabel ? (
+                            <a href={o.shippingLabel} download className="text-primary underline">
+                              Download
+                            </a>
+                          ) : (
+                            "-"
+                          )}
+                        </TableCell>
+                        <TableCell className="text-right">{formatCurrency(o.totalAmount)}</TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+            ) : (
+              <div className="text-center py-12 text-gray-500">No orders found</div>
+            )}
+          </CardContent>
+        </Card>
+      </main>
+      <Footer />
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- allow admins to access new Orders page
- show shipments details in admin order detail page
- add navigation link to the orders page in dashboard

## Testing
- `npm run check` *(fails: Cannot find module 'vite' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68655b0d9ac88330a75201f847d431cc