### PR TITLE
Fix admin dashboard button layout

### DIFF
--- a/client/src/pages/admin/dashboard.tsx
+++ b/client/src/pages/admin/dashboard.tsx
@@ -135,7 +135,7 @@ export default function AdminDashboard() {
               Platform overview and management
             </p>
           </div>
-          <div className="flex items-center space-x-4">
+          <div className="flex flex-wrap items-center gap-2 sm:gap-4">
             <Link href="/admin/users">
               <Button variant="outline" className="flex items-center">
                 <Users className="mr-2 h-4 w-4" />


### PR DESCRIPTION
## Summary
- allow action buttons on Admin Dashboard to wrap so they don't get cut off

## Testing
- `npm run check` *(fails: Cannot find module 'wouter' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68657736a5e48330963870c3a4980abf