### PR TITLE
Fix cart price recalculation on login/logout

### DIFF
--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -499,6 +499,7 @@ export interface CartItem {
   minOrderQuantity: number;
   orderMultiple: number;
   availableUnits: number;
+  priceIncludesFee?: boolean;
   offerId?: number;
   offerQuantity?: number;
   selectedVariations?: Record<string, string>;


### PR DESCRIPTION
## Summary
- ensure cart prices aren't repeatedly increased by persisting if service fee was applied
- include priceIncludesFee field in CartItem type
- adjust cart initialization and adding items to track service fee application

## Testing
- `npm run check` *(fails: ENOTFOUND registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_686578468b1c8330a8ad12d76b06c2df