### PR TITLE
Fix rounding loss when removing service fee

### DIFF
--- a/client/src/lib/utils.ts
+++ b/client/src/lib/utils.ts
@@ -7,9 +7,11 @@ export function cn(...inputs: ClassValue[]) {
 
 export const SERVICE_FEE_RATE = 0.035;
 
-// Remove the service fee and round to the nearest cent
+// Remove the service fee by reversing the addition logic. The price with fee
+// is rounded up when added, so we round down when removing to avoid losing
+// cents due to floating point math.
 export function removeServiceFee(priceWithFee: number): number {
-  return Math.round(priceWithFee * (1 - SERVICE_FEE_RATE) * 100) / 100;
+  return Math.floor((priceWithFee / (1 + SERVICE_FEE_RATE)) * 100) / 100;
 }
 
 // Round a number up to the nearest cent

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -218,7 +218,11 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
       const offerData = insertOfferSchema.parse({
         ...req.body,
-        price: req.body.price * (1 - SERVICE_FEE_RATE),
+        // Convert the buyer's total price to the seller's base price. The client
+        // sends the amount with the service fee included, so divide by the fee
+        // rate and round down to ensure addServiceFee(base) matches the offered
+        // total.
+        price: Math.floor((req.body.price / (1 + SERVICE_FEE_RATE)) * 100) / 100,
         productId: id,
         buyerId: user.id,
         sellerId: product.sellerId,


### PR DESCRIPTION
## Summary
- round down when removing the buyer service fee so we get the expected base price
- compute offer prices from buyer totals using the same rounding logic

## Testing
- `npm run check` *(fails: Cannot find module '@vitejs/plugin-react', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68658f02c9b083309ef49190df0b9764