### PR TITLE
Add seller payout email

### DIFF
--- a/client/src/pages/admin/billing.tsx
+++ b/client/src/pages/admin/billing.tsx
@@ -81,6 +81,11 @@ export default function AdminBillingPage() {
       await Promise.all(
         g.orders.map((o) => apiRequest("POST", `/api/admin/orders/${o.id}/mark-paid`)),
       );
+      await apiRequest("POST", "/api/admin/payouts/notify", {
+        sellerEmail: g.seller_email,
+        orders: g.orders.map(o => ({ code: o.code, total: o.total_amount })),
+        bankLast4: g.account_number?.slice(-4) ?? "",
+      });
     },
     onSuccess: () => {
       toast({ title: "Marked Paid" });


### PR DESCRIPTION
## Summary
- email seller when a payout is processed
- notify seller when admin marks payout paid

## Testing
- `npm run check` *(fails: Cannot find modules due to missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686592a7ffcc83308d51bc870fc3c6d1