### PR TITLE
Fix payout totals on admin billing dashboard

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1045,7 +1045,15 @@ export async function registerRoutes(app: Express): Promise<Server> {
   app.get("/api/admin/recent-payouts", isAuthenticated, isAdmin, async (_req, res) => {
     try {
       const payouts = await storage.getRecentPayouts(10);
-      res.json(payouts);
+      const result = [] as any[];
+      for (const p of payouts) {
+        const items = await storage.getOrderItems(p.id);
+        const productTotalWithFee = items.reduce((sum, i) => sum + Number(i.totalPrice), 0);
+        const shippingTotal = Number(p.total_amount) - productTotalWithFee;
+        const payoutAmount = productTotalWithFee * (1 - SERVICE_FEE_RATE) + shippingTotal;
+        result.push({ ...p, total_amount: payoutAmount });
+      }
+      res.json(result);
     } catch (error) {
       handleApiError(res, error);
     }


### PR DESCRIPTION
## Summary
- compute seller payout when fetching recent payouts

## Testing
- `npm run check` *(fails: ENOTFOUND registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_68659516aab48330b4c9a5fe01597b5e