### PR TITLE
Fix rounding loss when removing service fee

### DIFF
--- a/client/src/lib/utils.ts
+++ b/client/src/lib/utils.ts
@@ -7,9 +7,11 @@ export function cn(...inputs: ClassValue[]) {
 
 export const SERVICE_FEE_RATE = 0.035;
 
-// Remove the service fee and round to the nearest cent
+// Remove the service fee by reversing the addition logic. The price with fee
+// is rounded up when added, so we round down when removing to avoid losing
+// cents due to floating point math.
 export function removeServiceFee(priceWithFee: number): number {
-  return Math.round(priceWithFee * (1 - SERVICE_FEE_RATE) * 100) / 100;
+  return Math.floor((priceWithFee / (1 + SERVICE_FEE_RATE)) * 100) / 100;
 }
 
 // Round a number up to the nearest cent

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -38,6 +38,13 @@ import { containsContactInfo } from "./contactFilter";
 
 const SERVICE_FEE_RATE = 0.035;
 
+// Reverse the service fee addition logic. Prices with the fee applied are
+// rounded up, so divide by the fee rate and round down to recover the base
+// amount without losing cents.
+function removeServiceFee(priceWithFee: number): number {
+  return Math.floor((priceWithFee / (1 + SERVICE_FEE_RATE)) * 100) / 100;
+}
+
 async function fetchTrackingStatus(trackingNumber: string): Promise<string | undefined> {
   try {
     const apiKey = process.env.TRACKTRY_API_KEY;
@@ -218,7 +225,11 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
       const offerData = insertOfferSchema.parse({
         ...req.body,
-        price: req.body.price * (1 - SERVICE_FEE_RATE),
+        // Convert the buyer's total price to the seller's base price. The client
+        // sends the amount with the service fee included, so divide by the fee
+        // rate and round down to ensure addServiceFee(base) matches the offered
+        // total.
+        price: Math.floor((req.body.price / (1 + SERVICE_FEE_RATE)) * 100) / 100,
         productId: id,
         buyerId: user.id,
         sellerId: product.sellerId,
@@ -1019,7 +1030,11 @@ export async function registerRoutes(app: Express): Promise<Server> {
         const items = await storage.getOrderItems(o.id);
         const productTotalWithFee = items.reduce((sum, i) => sum + Number(i.totalPrice), 0);
         const shippingTotal = Number(o.total_amount) - productTotalWithFee;
-        const payoutAmount = productTotalWithFee * (1 - SERVICE_FEE_RATE) + shippingTotal;
+        // Calculate the seller payout by removing the service fee from the
+        // product total. Use the same rounding logic as when the fee was
+        // applied so the amount matches what sellers expect.
+        const payoutAmount =
+          Math.round((removeServiceFee(productTotalWithFee) + shippingTotal) * 100) / 100;
         groups[key].orders.push({ id: o.id, code: o.code, total_amount: payoutAmount });
         groups[key].total += payoutAmount;
       }
@@ -1041,6 +1056,18 @@ export async function registerRoutes(app: Express): Promise<Server> {
   app.get("/api/admin/recent-payouts", isAuthenticated, isAdmin, async (_req, res) => {
     try {
       const payouts = await storage.getRecentPayouts(10);
+      for (const p of payouts) {
+        const items = await storage.getOrderItems(p.id);
+        const productTotalWithFee = items.reduce(
+          (sum, i) => sum + Number(i.totalPrice),
+          0,
+        );
+        const shippingTotal = Number(p.total_amount) - productTotalWithFee;
+        // Match the payout calculation used when paying sellers
+        p.total_amount =
+          Math.round((removeServiceFee(productTotalWithFee) + shippingTotal) * 100) /
+          100;
+      }
       res.json(payouts);
     } catch (error) {
       handleApiError(res, error);


### PR DESCRIPTION
## Summary
- round down when removing the buyer service fee so we get the expected base price
- compute offer prices from buyer totals using the same rounding logic
- fix seller payout rounding on billing dashboard
- correct payout history totals to use the same rounding logic

## Testing
- `npm run check` *(fails: Cannot find module '@vitejs/plugin-react', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68658f02c9b083309ef49190df0b9764