### PR TITLE
Fix recent payouts route to return grouped results

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1050,19 +1050,39 @@ export async function registerRoutes(app: Express): Promise<Server> {
   app.get("/api/admin/recent-payouts", isAuthenticated, isAdmin, async (_req, res) => {
     try {
       const payouts = await storage.getRecentPayouts(10);
+      const groups: Record<number, any> = {};
       for (const p of payouts) {
+        const base = p.delivered_at ? new Date(p.delivered_at) : new Date();
+        const payoutDate = new Date(base);
+        payoutDate.setDate(payoutDate.getDate() + 7);
+        if (!groups[p.seller_id]) {
+          groups[p.seller_id] = {
+            seller_id: p.seller_id,
+            seller_first_name: p.seller_first_name,
+            seller_last_name: p.seller_last_name,
+            seller_email: p.seller_email,
+            payouts: [],
+            total: 0,
+          };
+        }
         const items = await storage.getOrderItems(p.id);
         const productTotalWithFee = items.reduce(
           (sum, i) => sum + Number(i.totalPrice),
           0,
         );
         const shippingTotal = Number(p.total_amount) - productTotalWithFee;
-        // Match the payout calculation used when paying sellers
-        p.total_amount =
+        const payoutAmount =
           Math.round((removeServiceFee(productTotalWithFee) + shippingTotal) * 100) /
           100;
+        groups[p.seller_id].payouts.push({
+          id: p.id,
+          code: p.code,
+          payout_date: payoutDate.toISOString(),
+          total_amount: payoutAmount,
+        });
+        groups[p.seller_id].total += payoutAmount;
       }
-      res.json(payouts);
+      res.json(Object.values(groups));
     } catch (error) {
       handleApiError(res, error);
     }


### PR DESCRIPTION
## Summary
- group recent payouts by seller on the backend

## Testing
- `npm run check` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68659d34cb2083309642923aa381d566