### PR TITLE
Add shipping totals to order details

### DIFF
--- a/client/src/lib/utils.ts
+++ b/client/src/lib/utils.ts
@@ -100,3 +100,8 @@ export function calculateSellerPayout(order: { items: { totalPrice: number }[]; 
   const shippingTotal = order.totalAmount - productTotalWithFee;
   return Math.round((removeServiceFee(productTotalWithFee) + shippingTotal) * 100) / 100;
 }
+
+export function calculateShippingTotal(order: { items: { totalPrice: number }[]; totalAmount: number }): number {
+  const productTotalWithFee = order.items.reduce((sum, i) => sum + i.totalPrice, 0);
+  return Math.max(order.totalAmount - productTotalWithFee, 0);
+}

--- a/client/src/pages/admin/order-detail.tsx
+++ b/client/src/pages/admin/order-detail.tsx
@@ -13,7 +13,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { CalendarIcon, ArrowLeft } from "lucide-react";
 import OrderStatus from "@/components/buyer/order-status";
-import { formatCurrency, formatDate } from "@/lib/utils";
+import { formatCurrency, formatDate, calculateShippingTotal } from "@/lib/utils";
 
 export default function AdminOrderDetailPage() {
   const { id } = useParams();
@@ -23,6 +23,7 @@ export default function AdminOrderDetailPage() {
     queryKey: ["/api/orders/" + orderId],
     enabled: !Number.isNaN(orderId),
   });
+  const shippingTotal = order ? calculateShippingTotal(order) : 0;
 
   if (isLoading) {
     return (
@@ -109,6 +110,13 @@ export default function AdminOrderDetailPage() {
                 ))}
               </ul>
             </div>
+
+            {shippingTotal > 0 && (
+              <div className="flex justify-between">
+                <span>Shipping</span>
+                <span>{formatCurrency(shippingTotal)}</span>
+              </div>
+            )}
 
             <div className="border-t pt-4 flex justify-between font-medium">
               <span>Total</span>

--- a/client/src/pages/buyer/order-detail.tsx
+++ b/client/src/pages/buyer/order-detail.tsx
@@ -19,7 +19,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { CalendarIcon, ArrowLeft } from "lucide-react";
 import OrderStatus from "@/components/buyer/order-status";
-import { formatCurrency, formatDate } from "@/lib/utils";
+import { formatCurrency, formatDate, calculateShippingTotal } from "@/lib/utils";
 
 export default function BuyerOrderDetailPage() {
   const { id } = useParams();
@@ -66,6 +66,7 @@ export default function BuyerOrderDetailPage() {
     queryKey: ["/api/orders/" + orderId],
     enabled: !Number.isNaN(orderId),
   });
+  const shippingTotal = order ? calculateShippingTotal(order) : 0;
 
   if (isLoading) {
     return (
@@ -147,6 +148,13 @@ export default function BuyerOrderDetailPage() {
                 ))}
               </ul>
             </div>
+
+            {shippingTotal > 0 && (
+              <div className="flex justify-between">
+                <span>Shipping</span>
+                <span>{formatCurrency(shippingTotal)}</span>
+              </div>
+            )}
 
             <div className="border-t pt-4 flex justify-between font-medium">
               <span>Total</span>

--- a/client/src/pages/seller/order-detail.tsx
+++ b/client/src/pages/seller/order-detail.tsx
@@ -22,6 +22,7 @@ import {
   formatDate,
   removeServiceFee,
   calculateSellerPayout,
+  calculateShippingTotal,
 } from "@/lib/utils";
 
 export default function SellerOrderDetailPage() {
@@ -32,6 +33,7 @@ export default function SellerOrderDetailPage() {
     queryKey: ["/api/orders/" + orderId],
     enabled: !Number.isNaN(orderId),
   });
+  const shippingTotal = order ? calculateShippingTotal(order) : 0;
 
   const queryClient = useQueryClient();
   const updateOrder = useMutation({
@@ -129,6 +131,13 @@ export default function SellerOrderDetailPage() {
                 ))}
               </ul>
             </div>
+
+            {shippingTotal > 0 && (
+              <div className="flex justify-between">
+                <span>Shipping</span>
+                <span>{formatCurrency(shippingTotal)}</span>
+              </div>
+            )}
 
             <div className="border-t pt-4 flex justify-between font-medium">
               <span>Total</span>


### PR DESCRIPTION
## Summary
- show shipping charges in order details for buyers, sellers and admins
- compute a reusable `calculateShippingTotal` helper

## Testing
- `npm run check` *(fails: Cannot find module 'wouter' ...)*

------
https://chatgpt.com/codex/tasks/task_e_6865a104256c8330912e4d46cc812a02