### PR TITLE
Fix invoice pdf download

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -425,7 +425,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
         "Content-Disposition",
         `attachment; filename=invoice-${order.code}.pdf`
       );
-      res.send(pdf);
+      res.end(pdf);
     } catch (error) {
       handleApiError(res, error);
     }


### PR DESCRIPTION
## Summary
- use `res.end` when sending invoice PDF to ensure data is sent as binary

## Testing
- `npm run check` *(fails: Cannot find module ...)*

------
https://chatgpt.com/codex/tasks/task_e_6865a11f3260833099fa2cb9a8233164