### PR TITLE
Fix message time formatting

### DIFF
--- a/client/src/components/messages/chat-message.tsx
+++ b/client/src/components/messages/chat-message.tsx
@@ -1,6 +1,5 @@
 import { Message } from "@shared/schema";
-import { format, parseISO } from "date-fns";
-import { utcToZonedTime } from "date-fns-tz";
+import { format } from "date-fns";
 
 interface ChatMessageProps {
   message: Message;
@@ -19,13 +18,7 @@ export default function ChatMessage({ message, isOwn }: ChatMessageProps) {
       >
         {message.content}
         <div className="text-xs text-muted-foreground mt-1 text-right">
-          {format(
-            utcToZonedTime(
-              parseISO(message.createdAt as unknown as string),
-              Intl.DateTimeFormat().resolvedOptions().timeZone,
-            ),
-            "p",
-          )}
+          {format(new Date(message.createdAt as unknown as string), "p")}
         </div>
       </div>
     </div>

--- a/client/src/components/messages/conversation-preview.tsx
+++ b/client/src/components/messages/conversation-preview.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { Link } from "wouter";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import { formatDistanceToNow, parseISO } from "date-fns";
+import { formatDistanceToNow } from "date-fns";
 import { Message, User } from "@shared/schema";
 import { getQueryFn } from "@/lib/queryClient";
 import { useAuth } from "@/hooks/use-auth";
@@ -44,7 +44,7 @@ export default function ConversationPreview({ otherId, selected }: ConversationP
           </span>
           {lastMessage && (
             <span className="text-gray-500 text-xs">
-              {formatDistanceToNow(parseISO(lastMessage.createdAt as unknown as string), { addSuffix: true })}
+              {formatDistanceToNow(new Date(lastMessage.createdAt as unknown as string), { addSuffix: true })}
             </span>
           )}
         </div>


### PR DESCRIPTION
## Summary
- fix chat timestamp parsing
- fix conversation preview timestamp parsing

## Testing
- `npm run check` *(fails: Cannot find module 'registry.npmjs.org' due to offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_6865b5a33d8883309b49ecf6dd3f8ed1