### PR TITLE
Fix useSearch import in seller products

### DIFF
--- a/client/src/pages/seller/products.tsx
+++ b/client/src/pages/seller/products.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
-import { Link, useLocation, useSearch } from "wouter";
+import { Link, useLocation } from "wouter";
+import { useSearch } from "wouter/use-location";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Product } from "@shared/schema";
 import { apiRequest } from "@/lib/queryClient";


### PR DESCRIPTION
## Summary
- import `useSearch` from `wouter/use-location` instead of `wouter`

## Testing
- `npm run check` *(fails: Cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_6865d67d19d083309a10d99a16ed89e0