### PR TITLE
Fix useSearch import

### DIFF
--- a/client/src/hooks/use-search.ts
+++ b/client/src/hooks/use-search.ts
@@ -1,0 +1,7 @@
+import { useLocation } from "wouter"
+
+export function useSearch() {
+  const [location] = useLocation()
+  const queryIndex = location.indexOf("?")
+  return queryIndex >= 0 ? location.substring(queryIndex) : ""
+}

--- a/client/src/pages/seller/products.tsx
+++ b/client/src/pages/seller/products.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from "react";
 import { Link, useLocation } from "wouter";
-import { useSearch } from "wouter/use-location";
+import { useSearch } from "@/hooks/use-search";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { Product } from "@shared/schema";
 import { apiRequest } from "@/lib/queryClient";


### PR DESCRIPTION
## Summary
- create a local `useSearch` hook
- update SellerProducts component to use the new hook

## Testing
- `npm run check` *(fails: Cannot find module 'wouter', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6865d9a5b53c83309516bbac4b719587