### PR TITLE
Add dotenv support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+# Example environment variables for sycloseouts
+PORT=5000
+DATABASE_URL=postgres://user:password@localhost:5432/dbname
+SMTP_HOST=smtp.example.com
+SMTP_PORT=587
+SMTP_USER=your-user
+SMTP_PASS=your-pass
+SMTP_FROM=info@example.com
+ADMIN_EMAIL=admin@example.com
+TRACKTRY_API_KEY=your-tracktry-key
+WIRE_ACCOUNT_NUMBER=12345678
+WIRE_ROUTING_NUMBER=12345678
+WIRE_INSTRUCTIONS=Optional instructions
+SESSION_SECRET=supersecret

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ dist
 server/public
 vite.config.ts.*
 *.tar.gz
+.env

--- a/README.md
+++ b/README.md
@@ -4,7 +4,10 @@ This project serves the API and client from a single Express server.
 
 ## Configuration
 
-The server reads the port from the `PORT` environment variable. If `PORT` is not set or is invalid, the server falls back to port `5000`.
+Copy `.env.example` to `.env` and fill in your credentials. The server reads all
+configuration values from this file. The `PORT` variable controls which port the
+server listens on. If it is not set or invalid, the server falls back to port
+`5000`.
 
 ```bash
 PORT=3000 npm run dev

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,3 +1,4 @@
+import "dotenv/config";
 import { defineConfig } from "drizzle-kit";
 
 if (!process.env.DATABASE_URL) {

--- a/package.json
+++ b/package.json
@@ -76,7 +76,8 @@
     "ws": "^8.18.0",
     "zod": "^3.24.2",
     "zod-validation-error": "^3.4.0",
-    "nodemailer": "^6.9.12"
+    "nodemailer": "^6.9.12",
+    "dotenv": "^16.3.2"
   },
   "devDependencies": {
     "@replit/vite-plugin-cartographer": "^0.1.2",

--- a/server/db.ts
+++ b/server/db.ts
@@ -1,3 +1,4 @@
+import "dotenv/config";
 import { Pool as NeonPool, neonConfig } from "@neondatabase/serverless";
 import { Pool as PgPool } from "pg";
 import { drizzle as drizzleNeon } from "drizzle-orm/neon-serverless";

--- a/server/email.ts
+++ b/server/email.ts
@@ -1,3 +1,4 @@
+import "dotenv/config";
 import nodemailer from "nodemailer";
 import path from "path";
 import { fileURLToPath } from "url";

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,3 +1,4 @@
+import "dotenv/config";
 import express, { type Request, Response, NextFunction } from "express";
 import { registerRoutes } from "./routes";
 import { setupVite, serveStatic, log } from "./vite";

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,3 +1,4 @@
+import "dotenv/config";
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import path from "path";


### PR DESCRIPTION
## Summary
- load environment variables from a `.env` file
- document dotenv usage
- ignore `.env` in git
- provide `.env.example`

## Testing
- `npm run check` *(fails: Cannot find module and other type errors)*

------
https://chatgpt.com/codex/tasks/task_e_686a90406dc88330810657ec4d4e7953