### PR TITLE
Fix pg import in server db

### DIFF
--- a/server/db.ts
+++ b/server/db.ts
@@ -1,6 +1,7 @@
 import "dotenv/config";
 import { Pool as NeonPool, neonConfig } from "@neondatabase/serverless";
-import { Pool as PgPool } from "pg";
+import pgPkg from "pg";
+const { Pool: PgPool } = pgPkg;
 import { drizzle as drizzleNeon } from "drizzle-orm/neon-serverless";
 import { drizzle as drizzlePg } from "drizzle-orm/node-postgres";
 import ws from "ws";


### PR DESCRIPTION
## Summary
- default-import pg in server

## Testing
- `npm run check` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686adf21c3f08330b7d3556880095b34