### PR TITLE
Allow direct seller signup

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -34,6 +34,7 @@ import SellerMessagesPage from "@/pages/seller/messages";
 import SellerAnalyticsPage from "@/pages/seller/analytics";
 import SellerPayoutPage from "@/pages/seller/payouts";
 import SellerApply from "@/pages/seller/apply";
+import SellerSignupPage from "@/pages/seller/signup";
 import OrderMessagesPage from "@/pages/order-messages";
 import ConversationPage from "@/pages/conversation";
 import AdminDashboard from "@/pages/admin/dashboard";
@@ -77,7 +78,8 @@ function Router() {
       <Route path="/help" component={HelpPage} />
       <ProtectedRoute path="/notifications" component={NotificationsPage} allowedRoles={["buyer", "seller", "admin"]} />
       
-      {/* Public seller application route */}
+      {/* Public seller routes */}
+      <Route path="/seller/signup" component={SellerSignupPage} />
       <Route path="/seller/apply" component={SellerApply} />
 
       {/* Buyer routes */}

--- a/client/src/pages/register.tsx
+++ b/client/src/pages/register.tsx
@@ -27,8 +27,8 @@ export default function RegisterChoicePage() {
               <Package className="h-12 w-12 text-primary mb-4" />
               <h2 className="text-2xl font-bold mb-2">Sell Your Inventory</h2>
               <p className="text-gray-600 mb-6">Reach thousands of resellers looking for liquidation inventory.</p>
-              <Link href="/seller/apply" className="w-full">
-                <Button variant="outline" className="w-full">Apply as Seller</Button>
+              <Link href="/seller/signup" className="w-full">
+                <Button variant="outline" className="w-full">Sign Up as Seller</Button>
               </Link>
             </div>
           </div>

--- a/client/src/pages/seller/signup.tsx
+++ b/client/src/pages/seller/signup.tsx
@@ -1,0 +1,412 @@
+import { useState, useRef } from "react";
+import { useLocation } from "wouter";
+import { registerSchema } from "@/hooks/use-auth";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import Header from "@/components/layout/header-fixed";
+import Footer from "@/components/layout/footer-fixed";
+import { CheckCircle, Loader2 } from "lucide-react";
+import { apiRequest } from "@/lib/queryClient";
+import { useToast } from "@/hooks/use-toast";
+
+const sellerSignupSchema = registerSchema
+  .omit({ role: true })
+  .extend({
+    role: z.literal("seller"),
+    inventoryType: z.string().min(1, "Inventory type is required"),
+    yearsInBusiness: z.coerce.number().min(0, "Years must be a positive number"),
+    website: z.string().optional(),
+    additionalInfo: z.string().optional(),
+  });
+
+type SellerSignupData = z.infer<typeof sellerSignupSchema>;
+
+export default function SellerSignupPage() {
+  const [, setLocation] = useLocation();
+  const { toast } = useToast();
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const [uploading, setUploading] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+
+  const form = useForm<SellerSignupData>({
+    resolver: zodResolver(sellerSignupSchema),
+    defaultValues: {
+      username: "",
+      password: "",
+      confirmPassword: "",
+      email: "",
+      firstName: "",
+      lastName: "",
+      company: "",
+      phone: "",
+      address: "",
+      city: "",
+      state: "",
+      zipCode: "",
+      country: "United States",
+      role: "seller",
+      resaleCertUrl: "",
+      inventoryType: "",
+      yearsInBusiness: 0,
+      website: "",
+      additionalInfo: "",
+    },
+  });
+
+  const handleFileUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setUploading(true);
+    const reader = new FileReader();
+    reader.onload = (event) => {
+      if (event.target && event.target.result) {
+        form.setValue("resaleCertUrl", event.target.result.toString());
+      }
+      setUploading(false);
+      if (fileInputRef.current) {
+        fileInputRef.current.value = "";
+      }
+    };
+    reader.onerror = () => setUploading(false);
+    reader.readAsDataURL(file);
+  };
+
+  const triggerFileUpload = () => fileInputRef.current?.click();
+
+  async function onSubmit(values: SellerSignupData) {
+    try {
+      const { confirmPassword, inventoryType, yearsInBusiness, website, additionalInfo, ...userData } = values;
+      await apiRequest("POST", "/api/register", userData);
+      await apiRequest("POST", "/api/seller-applications", {
+        contactName: `${values.firstName} ${values.lastName}`,
+        companyName: values.company || "",
+        contactEmail: values.email,
+        contactPhone: values.phone,
+        inventoryType,
+        yearsInBusiness,
+        website,
+        additionalInfo,
+      });
+      setSubmitted(true);
+      toast({ title: "Application Submitted", description: "We'll review your application soon." });
+    } catch (error: any) {
+      toast({ title: "Signup failed", description: error.message, variant: "destructive" });
+    }
+  }
+
+  return (
+    <>
+      <Header />
+      <main className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        {submitted ? (
+          <div className="text-center py-16">
+            <CheckCircle className="h-16 w-16 text-green-500 mx-auto mb-4" />
+            <h1 className="text-3xl font-extrabold text-gray-900 mb-4">Application Submitted!</h1>
+            <p className="text-lg text-gray-600 mb-8">Thank you for applying to sell on SY Closeouts.</p>
+            <Button onClick={() => setLocation("/")}>Return Home</Button>
+          </div>
+        ) : (
+          <div className="bg-white rounded-lg shadow-lg p-8">
+            <h2 className="text-2xl font-bold mb-6">Create a Seller Account</h2>
+            <Form {...form}>
+              <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+                <div className="grid grid-cols-2 gap-4">
+                  <FormField
+                    control={form.control}
+                    name="firstName"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>First Name</FormLabel>
+                        <FormControl>
+                          <Input {...field} />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="lastName"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>Last Name</FormLabel>
+                        <FormControl>
+                          <Input {...field} />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                </div>
+                <FormField
+                  control={form.control}
+                  name="username"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Username</FormLabel>
+                      <FormControl>
+                        <Input {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="email"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Email</FormLabel>
+                      <FormControl>
+                        <Input type="email" {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="company"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Company</FormLabel>
+                      <FormControl>
+                        <Input {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="phone"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Phone</FormLabel>
+                      <FormControl>
+                        <Input {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="address"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Street Address</FormLabel>
+                      <FormControl>
+                        <Input {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <div className="grid grid-cols-3 gap-4">
+                  <FormField
+                    control={form.control}
+                    name="city"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>City</FormLabel>
+                        <FormControl>
+                          <Input {...field} />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="state"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>State</FormLabel>
+                        <FormControl>
+                          <Input {...field} />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                  <FormField
+                    control={form.control}
+                    name="zipCode"
+                    render={({ field }) => (
+                      <FormItem>
+                        <FormLabel>ZIP</FormLabel>
+                        <FormControl>
+                          <Input {...field} />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                </div>
+                <FormField
+                  control={form.control}
+                  name="country"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Country</FormLabel>
+                      <FormControl>
+                        <Input {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="resaleCertUrl"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Resale Certificate</FormLabel>
+                      <FormControl>
+                        <Input type="hidden" {...field} />
+                      </FormControl>
+                      <Button type="button" variant="outline" className="mt-2" onClick={triggerFileUpload} disabled={uploading}>
+                        {uploading ? (
+                          <>
+                            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                            Uploading...
+                          </>
+                        ) : (
+                          "Upload File"
+                        )}
+                      </Button>
+                      {field.value && <p className="text-xs text-gray-500 mt-1">File attached</p>}
+                      <input type="file" ref={fileInputRef} onChange={handleFileUpload} className="hidden" accept="application/pdf,image/*" />
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="inventoryType"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Inventory Type</FormLabel>
+                      <Select onValueChange={field.onChange} defaultValue={field.value}>
+                        <FormControl>
+                          <SelectTrigger>
+                            <SelectValue placeholder="Select type" />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          <SelectItem value="Electronics">Electronics</SelectItem>
+                          <SelectItem value="Apparel">Apparel</SelectItem>
+                          <SelectItem value="Home Goods">Home Goods</SelectItem>
+                          <SelectItem value="Toys & Games">Toys & Games</SelectItem>
+                          <SelectItem value="Mixed Lots">Mixed Lots</SelectItem>
+                          <SelectItem value="Other">Other</SelectItem>
+                        </SelectContent>
+                      </Select>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="yearsInBusiness"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Years in Business</FormLabel>
+                      <FormControl>
+                        <Input type="number" min="0" {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="website"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Website</FormLabel>
+                      <FormControl>
+                        <Input {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="additionalInfo"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Additional Info</FormLabel>
+                      <FormControl>
+                        <Textarea className="h-28" {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="password"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Password</FormLabel>
+                      <FormControl>
+                        <Input type="password" {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name="confirmPassword"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Confirm Password</FormLabel>
+                      <FormControl>
+                        <Input type="password" {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+                <Button type="submit" className="w-full" disabled={form.formState.isSubmitting}>
+                  {form.formState.isSubmitting ? (
+                    <>
+                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                      Submitting...
+                    </>
+                  ) : (
+                    "Submit Application"
+                  )}
+                </Button>
+              </form>
+            </Form>
+          </div>
+        )}
+      </main>
+      <Footer />
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- add a seller signup form that creates the user and application together
- link to the new seller signup page from the register choice
- expose the route in the app router

## Testing
- `npm run check` *(fails: cannot download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686a9724b2bc8330b3bc0d3fbf73eb05