### PR TITLE
Fix query client imports

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,11 +1,11 @@
 import { Switch, Route } from "wouter";
-import { queryClient } from "./lib/queryClient";
+import { queryClient } from "@/lib/queryClient";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { Toaster } from "@/components/ui/toaster";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { AuthProvider } from "@/hooks/use-auth";
 import { CartProvider } from "@/hooks/use-cart";
-import { ProtectedRoute } from "./lib/protected-route";
+import { ProtectedRoute } from "@/lib/protected-route";
 import { ScrollToTop } from "@/lib/scroll-to-top";
 
 // Pages

--- a/client/src/pages/seller/signup.tsx
+++ b/client/src/pages/seller/signup.tsx
@@ -1,11 +1,11 @@
 import { Switch, Route } from "wouter";
-import { queryClient } from "./lib/queryClient";
+import { queryClient } from "@/lib/queryClient";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { Toaster } from "@/components/ui/toaster";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { AuthProvider } from "@/hooks/use-auth";
 import { CartProvider } from "@/hooks/use-cart";
-import { ProtectedRoute } from "./lib/protected-route";
+import { ProtectedRoute } from "@/lib/protected-route";
 import { ScrollToTop } from "@/lib/scroll-to-top";
 
 // Pages


### PR DESCRIPTION
## Summary
- use `@/lib` alias for queryClient and ProtectedRoute

## Testing
- `npm run check` *(fails: Cannot find module 'wouter' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_686bf9fa817c8330b9d0dff1303bacfb