### PR TITLE
Restrict seller dashboard until approval

### DIFF
--- a/client/src/lib/protected-route.tsx
+++ b/client/src/lib/protected-route.tsx
@@ -34,6 +34,15 @@ export function ProtectedRoute({
           return <Redirect to="/" />;
         }
 
+        if (
+          path.startsWith("/seller") &&
+          path !== "/seller/apply" &&
+          user.role === "seller" &&
+          (!user.isSeller || !user.isApproved)
+        ) {
+          return <Redirect to="/seller/apply" />;
+        }
+
         return <Component />;
       }}
     </Route>

--- a/client/src/pages/home-page.tsx
+++ b/client/src/pages/home-page.tsx
@@ -23,7 +23,10 @@ export default function HomePage() {
 
   if (user) {
     if (user.role === "seller") {
-      return <Redirect to="/seller/dashboard" />;
+      if (user.isSeller && user.isApproved) {
+        return <Redirect to="/seller/dashboard" />;
+      }
+      return <Redirect to="/seller/apply" />;
     }
     if (user.role === "buyer") {
       return <Redirect to="/buyer/home" />;


### PR DESCRIPTION
## Summary
- block seller routes for unapproved sellers
- redirect sellers back to application page when visiting `/`

## Testing
- `npm run check` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686d367372148330918143bf817dd94c