### PR TITLE
Fix additional info text input

### DIFF
--- a/client/src/pages/seller/apply.tsx
+++ b/client/src/pages/seller/apply.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useLocation } from "wouter";
 import { useAuth, registerSchema } from "@/hooks/use-auth";
 import { useForm } from "react-hook-form";
@@ -75,8 +75,9 @@ export default function SellerApply() {
     registerMutation.mutate(values);
   }
 
+  const hasSetDefaults = useRef(false)
   useEffect(() => {
-    if (user) {
+    if (user && !hasSetDefaults.current) {
       form.reset({
         contactName: `${user.firstName} ${user.lastName}`,
         companyName: user.company || "",
@@ -86,9 +87,10 @@ export default function SellerApply() {
         yearsInBusiness: 0,
         website: "",
         additionalInfo: "",
-      });
+      })
+      hasSetDefaults.current = true
     }
-  }, [user]);
+  }, [user, form])
 
   // Setup form with zod validation
   const form = useForm<ApplicationFormData>({
@@ -353,6 +355,8 @@ export default function SellerApply() {
                               <Input
                                 placeholder="Your company name"
                                 {...field}
+                                value={field.value}
+                                onChange={field.onChange}
                               />
                             </FormControl>
                             <FormMessage />
@@ -538,6 +542,8 @@ export default function SellerApply() {
                               <Input
                                 placeholder="Your company name"
                                 {...field}
+                                value={field.value}
+                                onChange={field.onChange}
                               />
                             </FormControl>
                             <FormMessage />
@@ -651,6 +657,8 @@ export default function SellerApply() {
                               <Input
                                 placeholder="https://www.example.com"
                                 {...field}
+                                value={field.value}
+                                onChange={field.onChange}
                               />
                             </FormControl>
                             <FormDescription>
@@ -673,6 +681,8 @@ export default function SellerApply() {
                                 placeholder="Tell us more about your business and inventory..."
                                 className="h-32"
                                 {...field}
+                                value={field.value}
+                                onChange={field.onChange}
                               />
                             </FormControl>
                             <FormDescription>


### PR DESCRIPTION
## Summary
- make the Additional Information textarea a controlled component
- keep name and ref props by spreading the field state
- also control Company Name and Website inputs
- keep application form stable once defaults are set

## Testing
- `npm run check` *(fails: cannot fetch packages)*

------
https://chatgpt.com/codex/tasks/task_e_686d38d51b388330836586a6148c46e7