### PR TITLE
Fix crypto polyfill for older Node

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
-    "db:push": "drizzle-kit push"
+    "db:push": "drizzle-kit push",
+    "test": "node --test"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,3 +1,4 @@
+import "./polyfills";
 import "dotenv/config";
 import express, { type Request, Response, NextFunction } from "express";
 import { registerRoutes } from "./routes";
@@ -87,3 +88,4 @@ app.use((req, res, next) => {
     }
   );
 })();
+

--- a/server/polyfills.js
+++ b/server/polyfills.js
@@ -1,0 +1,9 @@
+import { webcrypto } from "node:crypto";
+
+export function applyWebCryptoPolyfill() {
+  if (!globalThis.crypto || typeof globalThis.crypto.getRandomValues !== "function") {
+    globalThis.crypto = webcrypto;
+  }
+}
+
+applyWebCryptoPolyfill();

--- a/server/polyfills.test.js
+++ b/server/polyfills.test.js
@@ -1,0 +1,20 @@
+import { applyWebCryptoPolyfill } from './polyfills.js';
+import assert from 'node:assert';
+import { test } from 'node:test';
+
+// Ensure the polyfill installs global.crypto when missing
+
+test('applyWebCryptoPolyfill sets global.crypto', () => {
+  const original = globalThis.crypto;
+  delete globalThis.crypto;
+  applyWebCryptoPolyfill();
+  assert.ok(globalThis.crypto, 'crypto should be defined');
+  assert.strictEqual(typeof globalThis.crypto.getRandomValues, 'function');
+  // restore
+  if (original) {
+    globalThis.crypto = original;
+  } else {
+    delete globalThis.crypto;
+  }
+});
+


### PR DESCRIPTION
## Summary
- add global webcrypto polyfill so Vite can run on older Node versions
- test the new polyfill
- expose `npm test` script

## Testing
- `npm test`
- `npm run check` *(fails: Cannot find module 'wouter' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_686d432ea2e08330ba50b1358d55fb7d