### PR TITLE
Fix order creation for not-null code

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -36,6 +36,7 @@ import { eq } from "drizzle-orm";
 import { generateOrderCode } from "./orderCode";
 import { ZodError } from "zod";
 import { containsContactInfo } from "./contactFilter";
+import { randomBytes } from "crypto";
 
 const SERVICE_FEE_RATE = 0.035;
 
@@ -486,9 +487,10 @@ export async function registerRoutes(app: Express): Promise<Server> {
       }[] = [];
 
       const order = await db.transaction(async (tx) => {
+        const tempCode = randomBytes(8).toString("hex");
         const [createdOrder] = await tx
           .insert(ordersTable)
-          .values(orderData)
+          .values({ ...orderData, code: tempCode })
           .returning();
 
         const code = generateOrderCode(createdOrder.id);

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -19,6 +19,7 @@ import { db, pool } from "./db";
 import { eq, and, or, desc, SQL, ilike, lte, sql } from "drizzle-orm";
 import connectPgSimple from "connect-pg-simple";
 import { generateOrderCode } from "./orderCode";
+import { randomBytes } from "crypto";
 
 const PgStore = connectPgSimple(session);
 
@@ -304,7 +305,11 @@ export class DatabaseStorage implements IStorage {
   }
 
   async createOrder(insertOrder: InsertOrder): Promise<Order> {
-    const [order] = await db.insert(orders).values(insertOrder).returning();
+    const tempCode = randomBytes(8).toString("hex");
+    const [order] = await db
+      .insert(orders)
+      .values({ ...insertOrder, code: tempCode })
+      .returning();
     const code = generateOrderCode(order.id);
     const [withCode] = await db
       .update(orders)


### PR DESCRIPTION
## Summary
- generate temporary code values when inserting orders
- update routes and storage to insert temp codes before generating final order codes

## Testing
- `npm run check` *(fails: Cannot install packages)*

------
https://chatgpt.com/codex/tasks/task_e_686e9182a4288330b481594163d0b4cc