### PR TITLE
Fix number input scroll behavior

### DIFF
--- a/client/src/components/ui/input.tsx
+++ b/client/src/components/ui/input.tsx
@@ -3,12 +3,19 @@ import * as React from "react"
 import { cn } from "@/lib/utils"
 
 const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
-  ({ className, type, ...props }, ref) => {
+  ({ className, type, onWheel, ...props }, ref) => {
     const numberClasses =
       type === "number"
         ?
           "[appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
         : ""
+    const handleWheel: React.WheelEventHandler<HTMLInputElement> = e => {
+      if (type === "number") {
+        e.currentTarget.blur()
+      }
+      onWheel?.(e)
+    }
+
     return (
       <input
         type={type}
@@ -18,6 +25,7 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
           className
         )}
         ref={ref}
+        onWheel={handleWheel}
         {...props}
       />
     )


### PR DESCRIPTION
## Summary
- prevent scroll wheel from modifying number inputs

## Testing
- `npm run check` *(fails: Cannot find module 'wouter' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_686e953c329c8330815ff4cb6a0adead