### PR TITLE
Fix site settings retrieval import

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,6 +1,8 @@
 import { Switch, Route } from "wouter";
 import { queryClient } from "./lib/queryClient";
 import { QueryClientProvider } from "@tanstack/react-query";
+import { useEffect } from "react";
+import { useSettings, setServiceFeeRate } from "@/hooks/use-settings";
 import { Toaster } from "@/components/ui/toaster";
 import { TooltipProvider } from "@/components/ui/tooltip";
 import { AuthProvider } from "@/hooks/use-auth";
@@ -48,6 +50,7 @@ import AdminTicketsPage from "@/pages/admin/tickets";
 import AdminMessagesPage from "@/pages/admin/messages";
 import AdminUserProfilePage from "@/pages/admin/user-profile";
 import AdminEmailTemplatesPage from "@/pages/admin/email-templates";
+import AdminSettingsPage from "@/pages/admin/settings";
 import AboutPage from "@/pages/about-page";
 import SellerAgreementPage from "@/pages/seller-agreement";
 import BuyerAgreementPage from "@/pages/buyer-agreement";
@@ -55,6 +58,16 @@ import NotificationsPage from "@/pages/notifications-page";
 import SuspendedPage from "@/pages/suspended";
 import WireInstructionsPage from "@/pages/wire-instructions";
 import NotFound from "@/pages/not-found";
+
+function SettingsLoader() {
+  const { data } = useSettings();
+  useEffect(() => {
+    if (data && data.commissionRate !== undefined) {
+      setServiceFeeRate(data.commissionRate);
+    }
+  }, [data]);
+  return null;
+}
 
 function Router() {
   return (
@@ -111,6 +124,7 @@ function Router() {
       <ProtectedRoute path="/admin/orders/:id" component={AdminOrderDetailPage} allowedRoles={["admin"]} />
       <ProtectedRoute path="/admin/applications" component={AdminApplications} allowedRoles={["admin"]} />
       <ProtectedRoute path="/admin/featured" component={FeaturedProductsPage} allowedRoles={["admin"]} />
+      <ProtectedRoute path="/admin/settings" component={AdminSettingsPage} allowedRoles={["admin"]} />
       <ProtectedRoute path="/admin/messages" component={AdminMessagesPage} allowedRoles={["admin"]} />
       <ProtectedRoute path="/admin/email-templates" component={AdminEmailTemplatesPage} allowedRoles={["admin"]} />
       <ProtectedRoute path="/admin/tickets" component={AdminTicketsPage} allowedRoles={["admin"]} />
@@ -124,6 +138,7 @@ function Router() {
 function App() {
   return (
     <QueryClientProvider client={queryClient}>
+      <SettingsLoader />
       <AuthProvider>
         <CartProvider>
           <TooltipProvider>
@@ -136,5 +151,4 @@ function App() {
     </QueryClientProvider>
   );
 }
-
 export default App;

--- a/client/src/components/layout/footer-fixed.tsx
+++ b/client/src/components/layout/footer-fixed.tsx
@@ -8,12 +8,14 @@ import {
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { useSettings } from "@/hooks/use-settings";
 import { useState } from "react";
 import { useToast } from "@/hooks/use-toast";
 
 export default function Footer() {
   const [email, setEmail] = useState("");
   const { toast } = useToast();
+  const { data: settings } = useSettings();
   
   const handleSubscribe = (e: React.FormEvent) => {
     e.preventDefault();
@@ -30,7 +32,11 @@ export default function Footer() {
         <div className="xl:grid xl:grid-cols-3 xl:gap-8">
           <div className="space-y-8 xl:col-span-1">
             <Link href="/">
-              <span className="text-primary font-bold text-2xl cursor-pointer">SY Closeouts</span>
+              {settings?.logo ? (
+                <img src={settings.logo} alt="Logo" className="h-8 w-auto" />
+              ) : (
+                <span className="text-primary font-bold text-2xl cursor-pointer">SY Closeouts</span>
+              )}
             </Link>
             <p className="text-gray-400 text-base max-w-xs">
               Your trusted source for wholesale liquidation merchandise. 

--- a/client/src/components/layout/header-fixed.tsx
+++ b/client/src/components/layout/header-fixed.tsx
@@ -23,6 +23,7 @@ import { useCart } from "@/hooks/use-cart";
 import { useUnreadMessages } from "@/hooks/use-messages";
 import CartDrawer from "@/components/cart/cart-drawer";
 import MobileNav from "@/components/layout/mobile-nav";
+import { useSettings } from "@/hooks/use-settings";
 
 export default function Header() {
   const [location] = useLocation();
@@ -30,6 +31,7 @@ export default function Header() {
   const { itemCount, setIsCartOpen } = useCart();
   const unread = useUnreadMessages();
   const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const { data: settings } = useSettings();
 
   const isActive = (path: string) => {
     return location === path;
@@ -47,7 +49,11 @@ export default function Header() {
             <div className="flex">
               <div className="flex-shrink-0 flex items-center">
                 <Link href="/">
-                  <span className="text-primary font-bold text-2xl cursor-pointer">SY Closeouts</span>
+                  {settings?.logo ? (
+                    <img src={settings.logo} alt="Logo" className="h-8 w-auto" />
+                  ) : (
+                    <span className="text-primary font-bold text-2xl cursor-pointer">SY Closeouts</span>
+                  )}
                 </Link>
               </div>
               <nav className="hidden sm:ml-6 sm:flex sm:space-x-8 items-center">

--- a/client/src/components/layout/header.tsx
+++ b/client/src/components/layout/header.tsx
@@ -23,6 +23,7 @@ import { useAuth } from "@/hooks/use-auth";
 import { useCart } from "@/hooks/use-cart";
 import { useUnreadMessages } from "@/hooks/use-messages";
 import { useUnreadNotifications } from "@/hooks/use-notifications";
+import { useSettings } from "@/hooks/use-settings";
 import CartDrawer from "@/components/cart/cart-drawer";
 import MobileNav from "@/components/layout/mobile-nav";
 import { ReactNode } from "react";
@@ -39,6 +40,7 @@ export default function Header({ dashboardTabs, onProfileClick }: HeaderProps) {
   const { itemCount, setIsCartOpen } = useCart();
   const unread = useUnreadMessages();
   const unreadNotifs = useUnreadNotifications();
+  const { data: settings } = useSettings();
 
   const handleLogout = () => logoutMutation.mutate();
   const isActive = (path: string) => location === path;
@@ -56,9 +58,11 @@ export default function Header({ dashboardTabs, onProfileClick }: HeaderProps) {
             <div className="flex">
               <div className="flex-shrink-0 flex items-center">
                 <Link href="/">
-                  <span className="text-primary font-bold text-2xl cursor-pointer">
-                    SY Closeouts
-                  </span>
+                  {settings?.logo ? (
+                    <img src={settings.logo} alt="Logo" className="h-8 w-auto" />
+                  ) : (
+                    <span className="text-primary font-bold text-2xl cursor-pointer">SY Closeouts</span>
+                  )}
                 </Link>
               </div>
               <nav className="hidden sm:ml-6 sm:flex sm:space-x-8 items-center">

--- a/client/src/hooks/use-settings.tsx
+++ b/client/src/hooks/use-settings.tsx
@@ -1,0 +1,30 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { apiRequest } from "@/lib/queryClient";
+
+export interface SiteSettings {
+  commissionRate: number;
+  logo?: string | null;
+}
+
+export const DEFAULT_SERVICE_FEE_RATE = 0.035;
+
+let serviceFeeRate = DEFAULT_SERVICE_FEE_RATE;
+export function setServiceFeeRate(rate: number) {
+  serviceFeeRate = rate;
+}
+export function getServiceFeeRate() {
+  return serviceFeeRate;
+}
+
+export function useSettings() {
+  return useQuery<SiteSettings>({ queryKey: ["/api/settings"] });
+}
+
+export function useUpdateSettings() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (values: Partial<SiteSettings>) =>
+      apiRequest("PUT", "/api/admin/settings", values),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["/api/settings"] }),
+  });
+}

--- a/client/src/pages/admin/dashboard.tsx
+++ b/client/src/pages/admin/dashboard.tsx
@@ -34,15 +34,14 @@ import {
   Mail
 } from "lucide-react";
 import { useAuth } from "@/hooks/use-auth";
-import {
-  formatCurrency,
-  SERVICE_FEE_RATE,
-  calculateOrderCommission,
-} from "@/lib/utils";
+import { formatCurrency, calculateOrderCommission } from "@/lib/utils";
+import { useSettings, DEFAULT_SERVICE_FEE_RATE } from "@/hooks/use-settings";
 
 export default function AdminDashboard() {
   const { user } = useAuth();
   const [activeTab, setActiveTab] = useState("overview");
+  const { data: settings } = useSettings();
+  const feeRate = settings?.commissionRate ?? DEFAULT_SERVICE_FEE_RATE;
   
   // Fetch all users
   const {
@@ -170,6 +169,12 @@ export default function AdminDashboard() {
                 Featured Products
               </Button>
             </Link>
+            <Link href="/admin/settings">
+              <Button variant="outline" className="flex items-center">
+                <LayoutDashboard className="mr-2 h-4 w-4" />
+                Settings
+              </Button>
+            </Link>
             <Link href="/admin/email-templates">
               <Button variant="outline" className="flex items-center">
                 <Mail className="mr-2 h-4 w-4" />
@@ -213,7 +218,7 @@ export default function AdminDashboard() {
                     <CardContent>
                       <div className="text-sm text-gray-500 flex items-center">
                         <Calculator className="h-4 w-4 mr-1 text-green-500" />
-                        3.5% commission on {formatCurrency(productRevenue)}
+                        {(feeRate * 100).toFixed(1)}% commission on {formatCurrency(productRevenue)}
                       </div>
                     </CardContent>
                   </Card>
@@ -512,7 +517,7 @@ export default function AdminDashboard() {
                         </CardHeader>
                         <CardContent>
                           <div className="text-sm text-gray-500">
-                            3.5% commission on all products
+                            {(feeRate * 100).toFixed(1)}% commission on all products
                           </div>
                         </CardContent>
                       </Card>

--- a/client/src/pages/admin/settings.tsx
+++ b/client/src/pages/admin/settings.tsx
@@ -1,0 +1,90 @@
+import { useEffect, useRef, useState } from "react";
+import Header from "@/components/layout/header";
+import Footer from "@/components/layout/footer";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Loader2, ImagePlus } from "lucide-react";
+import { useSettings, useUpdateSettings } from "@/hooks/use-settings";
+
+export default function AdminSettingsPage() {
+  const { data, isLoading } = useSettings();
+  const update = useUpdateSettings();
+  const [rate, setRate] = useState(0.035);
+  const [logo, setLogo] = useState<string | null>(null);
+  const fileRef = useRef<HTMLInputElement | null>(null);
+  const [uploading, setUploading] = useState(false);
+
+  useEffect(() => {
+    if (data) {
+      setRate(data.commissionRate);
+      setLogo(data.logo ?? null);
+    }
+  }, [data]);
+
+  const handleFile = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setUploading(true);
+    const reader = new FileReader();
+    reader.onload = ev => {
+      if (ev.target?.result) {
+        setLogo(ev.target.result.toString());
+      }
+      setUploading(false);
+    };
+    reader.onerror = () => setUploading(false);
+    reader.readAsDataURL(file);
+  };
+
+  const trigger = () => fileRef.current?.click();
+
+  const save = () => {
+    update.mutate({ commissionRate: rate, logo });
+  };
+
+  if (isLoading) {
+    return (
+      <>
+        <Header />
+        <main className="max-w-7xl mx-auto px-4 py-12 flex justify-center">
+          <Loader2 className="h-8 w-8 animate-spin" />
+        </main>
+        <Footer />
+      </>
+    );
+  }
+
+  return (
+    <>
+      <Header />
+      <main className="max-w-7xl mx-auto px-4 py-8">
+        <h1 className="text-3xl font-extrabold tracking-tight mb-6">Site Settings</h1>
+        <Card>
+          <CardHeader>
+            <CardTitle>General</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div>
+              <label className="block text-sm font-medium mb-1">Commission Rate (%)</label>
+              <Input type="number" step="0.01" value={rate} onChange={e => setRate(parseFloat(e.target.value))} />
+            </div>
+            <div>
+              <label className="block text-sm font-medium mb-1">Logo</label>
+              {logo && <img src={logo} alt="Logo" className="h-16 mb-2" />}
+              <Input value={logo || ""} onChange={e => setLogo(e.target.value)} placeholder="Image URL or data" />
+              <input type="file" ref={fileRef} className="hidden" accept="image/*" onChange={handleFile} />
+              <Button type="button" variant="outline" className="mt-2" onClick={trigger} disabled={uploading}>
+                {uploading ? (<><Loader2 className="mr-2 h-4 w-4 animate-spin"/>Uploading...</>) : (<><ImagePlus className="mr-2 h-4 w-4"/>Upload Image</>)}
+              </Button>
+            </div>
+            <Button onClick={save} disabled={update.isPending}>
+              {update.isPending ? (<><Loader2 className="mr-2 h-4 w-4 animate-spin"/>Saving...</>) : "Save"}
+            </Button>
+          </CardContent>
+        </Card>
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/client/src/pages/buyer/offers.tsx
+++ b/client/src/pages/buyer/offers.tsx
@@ -2,7 +2,8 @@ import { useQuery, useMutation } from "@tanstack/react-query";
 import { Offer } from "@shared/schema";
 import Header from "@/components/layout/header";
 import Footer from "@/components/layout/footer";
-import { formatCurrency, SERVICE_FEE_RATE, cn } from "@/lib/utils";
+import { formatCurrency, cn } from "@/lib/utils";
+import { getServiceFeeRate } from "@/hooks/use-settings";
 import { apiRequest, queryClient } from "@/lib/queryClient";
 import { useToast } from "@/hooks/use-toast";
 import { useCart } from "@/hooks/use-cart";
@@ -146,7 +147,7 @@ export default function BuyerOffersPage() {
                             <p className="text-sm">Quantity: {o.quantity}</p>
                           </div>
                           <div className="text-right space-y-1">
-                            <p>{formatCurrency(o.price * (1 + SERVICE_FEE_RATE))}</p>
+                            <p>{formatCurrency(o.price * (1 + getServiceFeeRate()))}</p>
                             <span className="text-xs capitalize">{o.status}</span>
                           </div>
                         </div>

--- a/client/src/pages/seller/dashboard.tsx
+++ b/client/src/pages/seller/dashboard.tsx
@@ -50,12 +50,7 @@ import {
   ListOrdered
 } from "lucide-react";
 import { useAuth } from "@/hooks/use-auth";
-import {
-  formatCurrency,
-  formatDate,
-  SERVICE_FEE_RATE,
-  calculateSellerPayout,
-} from "@/lib/utils";
+import { formatCurrency, formatDate, calculateSellerPayout } from "@/lib/utils";
 
 interface OrderItemWithProduct extends OrderItem {
   productTitle: string;

--- a/client/src/pages/seller/payouts.tsx
+++ b/client/src/pages/seller/payouts.tsx
@@ -4,12 +4,7 @@ import Footer from "@/components/layout/footer";
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { useQuery } from "@tanstack/react-query";
 import { Order, OrderItem } from "@shared/schema";
-import {
-  formatCurrency,
-  formatDate,
-  SERVICE_FEE_RATE,
-  calculateSellerPayout,
-} from "@/lib/utils";
+import { formatCurrency, formatDate, calculateSellerPayout } from "@/lib/utils";
 import { useAuth } from "@/hooks/use-auth";
 import { Button } from "@/components/ui/button";
 import { Link } from "wouter";

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1,6 +1,5 @@
 import type { Express } from "express";
 import { createServer, type Server } from "http";
-import { storage } from "./storage";
 import { setupAuth, isAuthenticated, isSeller, isAdmin } from "./auth";
 import {
   sendInvoiceEmail,
@@ -37,14 +36,17 @@ import { generateOrderCode } from "./orderCode";
 import { ZodError } from "zod";
 import { containsContactInfo } from "./contactFilter";
 import { randomBytes } from "crypto";
+import { storage } from "./storage";
 
-const SERVICE_FEE_RATE = 0.035;
+async function getServiceFeeRate(): Promise<number> {
+  const val = await storage.getSiteSetting("commission_rate");
+  const num = parseFloat(val ?? "0.035");
+  return Number.isFinite(num) ? num : 0.035;
+}
 
-// Reverse the service fee addition logic. Prices with the fee applied are
-// rounded up, so divide by the fee rate and round down to recover the base
-// amount without losing cents.
-function removeServiceFee(priceWithFee: number): number {
-  return Math.floor((priceWithFee / (1 + SERVICE_FEE_RATE)) * 100) / 100;
+// Reverse the service fee addition logic using a provided rate
+function removeServiceFee(priceWithFee: number, rate: number): number {
+  return Math.floor((priceWithFee / (1 + rate)) * 100) / 100;
 }
 
 async function fetchTrackingStatus(trackingNumber: string): Promise<string | undefined> {
@@ -225,13 +227,13 @@ export async function registerRoutes(app: Express): Promise<Server> {
         return res.status(400).json({ message: "Quantity exceeds available stock" });
       }
 
+      const rate = await getServiceFeeRate();
       const offerData = insertOfferSchema.parse({
         ...req.body,
-        // Convert the buyer's total price to the seller's base price. The client
-        // sends the amount with the service fee included, so divide by the fee
-        // rate and round down to ensure addServiceFee(base) matches the offered
-        // total.
-        price: Math.floor((req.body.price / (1 + SERVICE_FEE_RATE)) * 100) / 100,
+        // Convert the buyer's total price to the seller's base price using the
+        // current service fee rate and round down so addServiceFee(base)
+        // matches the offered total.
+        price: Math.floor((req.body.price / (1 + rate)) * 100) / 100,
         productId: id,
         buyerId: user.id,
         sellerId: product.sellerId,
@@ -993,6 +995,40 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
+  app.get("/api/settings", async (_req, res) => {
+    try {
+      const rate = await getServiceFeeRate();
+      const logo = await storage.getSiteSetting("logo");
+      res.json({ commissionRate: rate, logo });
+    } catch (error) {
+      handleApiError(res, error);
+    }
+  });
+
+  app.get("/api/admin/settings", isAuthenticated, isAdmin, async (_req, res) => {
+    try {
+      const rate = await getServiceFeeRate();
+      const logo = await storage.getSiteSetting("logo");
+      res.json({ commissionRate: rate, logo });
+    } catch (error) {
+      handleApiError(res, error);
+    }
+  });
+
+  app.put("/api/admin/settings", isAuthenticated, isAdmin, async (req, res) => {
+    try {
+      if (req.body.commissionRate !== undefined) {
+        await storage.setSiteSetting("commission_rate", String(req.body.commissionRate));
+      }
+      if (req.body.logo !== undefined) {
+        await storage.setSiteSetting("logo", req.body.logo ?? "");
+      }
+      res.sendStatus(204);
+    } catch (error) {
+      handleApiError(res, error);
+    }
+  });
+
   app.get("/api/admin/billing", isAuthenticated, isAdmin, async (_req, res) => {
     try {
       const orders = await storage.getOrdersForBilling();
@@ -1028,11 +1064,12 @@ export async function registerRoutes(app: Express): Promise<Server> {
         const items = await storage.getOrderItems(o.id);
         const productTotalWithFee = items.reduce((sum, i) => sum + Number(i.totalPrice), 0);
         const shippingTotal = Number(o.total_amount) - productTotalWithFee;
+        const rate = await getServiceFeeRate();
         // Calculate the seller payout by removing the service fee from the
         // product total. Use the same rounding logic as when the fee was
         // applied so the amount matches what sellers expect.
         const payoutAmount =
-          Math.round((removeServiceFee(productTotalWithFee) + shippingTotal) * 100) / 100;
+          Math.round((removeServiceFee(productTotalWithFee, rate) + shippingTotal) * 100) / 100;
         groups[key].orders.push({ id: o.id, code: o.code, total_amount: payoutAmount });
         groups[key].total += payoutAmount;
       }
@@ -1075,8 +1112,9 @@ export async function registerRoutes(app: Express): Promise<Server> {
           0,
         );
         const shippingTotal = Number(p.total_amount) - productTotalWithFee;
+        const rate = await getServiceFeeRate();
         const payoutAmount =
-          Math.round((removeServiceFee(productTotalWithFee) + shippingTotal) * 100) /
+          Math.round((removeServiceFee(productTotalWithFee, rate) + shippingTotal) * 100) /
           100;
         groups[p.seller_id].payouts.push({
           id: p.id,

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -12,7 +12,8 @@ import {
   offers, Offer, InsertOffer,
   supportTickets, SupportTicket, InsertSupportTicket,
   notifications, Notification, InsertNotification,
-  emailTemplates, EmailTemplate, InsertEmailTemplate
+  emailTemplates, EmailTemplate, InsertEmailTemplate,
+  siteSettings
 } from "@shared/schema";
 import session from "express-session";
 import { db, pool } from "./db";
@@ -124,6 +125,10 @@ export interface IStorage {
   // Cart methods
   getCart(userId: number): Promise<Cart | undefined>;
   createOrUpdateCart(cart: InsertCart): Promise<Cart>;
+
+  // Site setting methods
+  getSiteSetting(key: string): Promise<string | undefined>;
+  setSiteSetting(key: string, value: string): Promise<void>;
   
   // Session store
   sessionStore: session.Store;
@@ -839,7 +844,26 @@ export class DatabaseStorage implements IStorage {
       return newCart;
     }
   }
+
+  async getSiteSetting(key: string): Promise<string | undefined> {
+    const [row] = await db
+      .select()
+      .from(siteSettings)
+      .where(eq(siteSettings.key, key));
+    return row?.value as string | undefined;
+  }
+
+  async setSiteSetting(key: string, value: string): Promise<void> {
+    const existing = await this.getSiteSetting(key);
+    if (existing !== undefined) {
+      await db
+        .update(siteSettings)
+        .set({ value })
+        .where(eq(siteSettings.key, key));
+    } else {
+      await db.insert(siteSettings).values({ key, value });
+    }
+  }
 }
 
-// Export an instance of the storage
-export const storage = new DatabaseStorage();
+// Export an instance of the storageexport const storage = new DatabaseStorage();

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -450,6 +450,14 @@ export const insertNotificationSchema = createInsertSchema(notifications).omit({
   createdAt: true,
 });
 
+// Site-wide settings key/value store
+export const siteSettings = pgTable("site_settings", {
+  key: text("key").primaryKey(),
+  value: text("value").notNull(),
+});
+
+export const insertSiteSettingSchema = createInsertSchema(siteSettings);
+
 // Type definitions
 export type User = typeof users.$inferSelect;
 export type InsertUser = z.infer<typeof insertUserSchema>;
@@ -496,6 +504,9 @@ export type InsertNotification = z.infer<typeof insertNotificationSchema>;
 export type EmailTemplate = typeof emailTemplates.$inferSelect;
 export type InsertEmailTemplate = z.infer<typeof insertEmailTemplateSchema>;
 
+export type SiteSetting = typeof siteSettings.$inferSelect;
+export type InsertSiteSetting = z.infer<typeof insertSiteSettingSchema>;
+
 // Cart item interface for the frontend
 export interface CartItem {
   productId: number;
@@ -510,5 +521,4 @@ export interface CartItem {
   offerId?: number;
   offerQuantity?: number;
   selectedVariations?: Record<string, string>;
-  variationKey?: string;
-}
+  variationKey?: string;}


### PR DESCRIPTION
## Summary
- ensure `siteSettings` table is imported in storage
- remove duplicate `storage` import in routes
- keep API routes for updating logo and commission rate

## Testing
- `npm run check` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686e97909f108330800ad29a7b5bd7d2