### PR TITLE
Fix storage export line

### DIFF
--- a/server/storage.ts
+++ b/server/storage.ts
@@ -865,5 +865,5 @@ export class DatabaseStorage implements IStorage {
     }
   }
 }
-
-// Export an instance of the storageexport const storage = new DatabaseStorage();
+// Export an instance of the storage
+export const storage = new DatabaseStorage();


### PR DESCRIPTION
## Summary
- split the Storage export into a separate line so it is not commented out

## Testing
- `npm run check` *(fails: Cannot find modules)*
- `NODE_ENV=development tsx server/index.ts` *(fails: `tsx` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ea61356348330946c0fb46f10e1bd