### PR TITLE
Expand logo vertically

### DIFF
--- a/client/src/components/layout/header-fixed.tsx
+++ b/client/src/components/layout/header-fixed.tsx
@@ -50,7 +50,7 @@ export default function Header() {
               <div className="flex-shrink-0 flex items-center">
                 <Link href="/">
                   {settings?.logo ? (
-                    <img src={settings.logo} alt="Logo" className="h-8 w-auto" />
+                    <img src={settings.logo} alt="Logo" className="h-full w-auto" />
                   ) : (
                     <span className="text-primary font-bold text-2xl cursor-pointer">SY Closeouts</span>
                   )}

--- a/client/src/components/layout/header.tsx
+++ b/client/src/components/layout/header.tsx
@@ -59,7 +59,7 @@ export default function Header({ dashboardTabs, onProfileClick }: HeaderProps) {
               <div className="flex-shrink-0 flex items-center">
                 <Link href="/">
                   {settings?.logo ? (
-                    <img src={settings.logo} alt="Logo" className="h-8 w-auto" />
+                    <img src={settings.logo} alt="Logo" className="h-full w-auto" />
                   ) : (
                     <span className="text-primary font-bold text-2xl cursor-pointer">SY Closeouts</span>
                   )}


### PR DESCRIPTION
## Summary
- make the header logo use the full height of the bar

## Testing
- `npm run check` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_686ea95a7cb8833084cd02c6b352382b