### PR TITLE
Increase JSON size limit for uploads

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -5,7 +5,8 @@ import { setupVite, serveStatic, log } from "./vite";
 
 const app = express();
 // Increase JSON body size limit to handle base64-encoded images
-app.use(express.json({ limit: "10mb" }));
+// and larger file uploads like profile pictures
+app.use(express.json({ limit: "50mb" }));
 app.use(express.urlencoded({ extended: false }));
 
 app.use((req, res, next) => {


### PR DESCRIPTION
## Summary
- bump Express JSON body limit to 50 MB to allow larger profile picture uploads

## Testing
- `npm run check` *(fails: Cannot find module)*

------
https://chatgpt.com/codex/tasks/task_e_686ead2a3f24833090f2c25fe11e109c