### PR TITLE
Increase JSON and urlencoded body limits

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -5,8 +5,10 @@ import { setupVite, serveStatic, log } from "./vite";
 
 const app = express();
 // Increase JSON body size limit to handle base64-encoded images
-app.use(express.json({ limit: "10mb" }));
-app.use(express.urlencoded({ extended: false }));
+// and larger file uploads like profile pictures
+app.use(express.json({ limit: "50mb" }));
+// Also allow larger URL-encoded payloads for forms that submit images
+app.use(express.urlencoded({ extended: false, limit: "50mb" }));
 
 app.use((req, res, next) => {
   const start = Date.now();


### PR DESCRIPTION
## Summary
- bump Express urlencoded limit to match JSON limit for handling image uploads

## Testing
- `npm run check` *(fails to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686ead2a3f24833090f2c25fe11e109c