### PR TITLE
Fix email logo variable and address update

### DIFF
--- a/server/email.ts
+++ b/server/email.ts
@@ -322,6 +322,7 @@ export async function sendSellerOrderEmail(
   </body>
 </html>`;
 
+  const logo = await getLogoAttachment();
   const mailOptions = {
     from: process.env.SMTP_FROM || user,
     to,
@@ -474,6 +475,7 @@ export async function sendPasswordResetEmail(to: string, code: string) {
     </body>
   </html>`;
 
+  const logo = await getLogoAttachment();
   const mailOptions = {
     from: process.env.SMTP_FROM || user,
     to,
@@ -648,10 +650,11 @@ export async function sendWireInstructionsEmail(to: string, order: Order) {
             </table>
           </td>
         </tr>
-      </table>
+  </table>
     </body>
   </html>`;
 
+  const logo = await getLogoAttachment();
   const mailOptions = {
     from: process.env.SMTP_FROM || user,
     to,
@@ -768,6 +771,7 @@ export async function sendSellerPayoutEmail(
   </body>
 </html>`;
 
+  const logo = await getLogoAttachment();
   const mailOptions = {
     from: process.env.SMTP_FROM || user,
     to,

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -2014,7 +2014,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
         return res.status(404).json({ message: "Address not found" });
       }
 
-      const updated = await storage.updateAddress(id, req.body);
+      const { id: _ignore, createdAt, ...data } = req.body as Record<string, any>;
+      const updated = await storage.updateAddress(id, data);
       res.json(updated);
     } catch (error) {
       handleApiError(res, error);


### PR DESCRIPTION
## Summary
- attach logo in SellerOrder, WireInstructions, and Payout emails
- drop `createdAt` field when updating an address

## Testing
- `npm run check` *(fails: Cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_686eb4ebd2bc8330a336c706e462fd70