### PR TITLE
Fix runtime error on seller application page

### DIFF
--- a/client/src/pages/seller/apply.tsx
+++ b/client/src/pages/seller/apply.tsx
@@ -76,6 +76,21 @@ export default function SellerApply() {
     registerMutation.mutate(values);
   }
 
+  // Setup form with zod validation
+  const form = useForm<ApplicationFormData>({
+    resolver: zodResolver(applicationSchema),
+    defaultValues: {
+      contactName: user ? `${user.firstName} ${user.lastName}` : "",
+      companyName: user?.company || "",
+      contactEmail: user?.email || "",
+      contactPhone: "",
+      inventoryType: "",
+      yearsInBusiness: 0,
+      website: "",
+      additionalInfo: "",
+    },
+  });
+
   useEffect(() => {
     if (user && !hasInitialized.current) {
       form.reset({
@@ -91,21 +106,6 @@ export default function SellerApply() {
       hasInitialized.current = true;
     }
   }, [user, form]);
-
-  // Setup form with zod validation
-  const form = useForm<ApplicationFormData>({
-    resolver: zodResolver(applicationSchema),
-    defaultValues: {
-      contactName: user ? `${user.firstName} ${user.lastName}` : "",
-      companyName: user?.company || "",
-      contactEmail: user?.email || "",
-      contactPhone: "",
-      inventoryType: "",
-      yearsInBusiness: 0,
-      website: "",
-      additionalInfo: "",
-    },
-  });
 
   // Handle form submission with React Query
   const { mutate: submitApplication, isPending } = useMutation({


### PR DESCRIPTION
## Summary
- move form initialization before `useEffect` in `seller/apply` page to avoid accessing a variable before it is defined

## Testing
- `npm run check` *(fails: cannot access internet to install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686ebe69e5dc8330bef29c7db836d4ce