### PR TITLE
Fix input default type

### DIFF
--- a/client/src/components/ui/input.tsx
+++ b/client/src/components/ui/input.tsx
@@ -3,7 +3,7 @@ import * as React from "react"
 import { cn } from "@/lib/utils"
 
 const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
-  ({ className, type, onWheel, ...props }, ref) => {
+  ({ className, type = "text", onWheel, ...props }, ref) => {
     const numberClasses =
       type === "number"
         ?


### PR DESCRIPTION
## Summary
- fix input default type to ensure text fields are editable

## Testing
- `npm run check` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686ebf91df5c8330a13809e259d0c837