### PR TITLE
Implement admin strike management

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -51,6 +51,7 @@ import AdminMessagesPage from "@/pages/admin/messages";
 import AdminUserProfilePage from "@/pages/admin/user-profile";
 import AdminEmailTemplatesPage from "@/pages/admin/email-templates";
 import AdminSettingsPage from "@/pages/admin/settings";
+import AdminStrikesPage from "@/pages/admin/strikes";
 import AboutPage from "@/pages/about-page";
 import SellerAgreementPage from "@/pages/seller-agreement";
 import BuyerAgreementPage from "@/pages/buyer-agreement";
@@ -127,6 +128,7 @@ function Router() {
       <ProtectedRoute path="/admin/settings" component={AdminSettingsPage} allowedRoles={["admin"]} />
       <ProtectedRoute path="/admin/messages" component={AdminMessagesPage} allowedRoles={["admin"]} />
       <ProtectedRoute path="/admin/email-templates" component={AdminEmailTemplatesPage} allowedRoles={["admin"]} />
+      <ProtectedRoute path="/admin/strikes" component={AdminStrikesPage} allowedRoles={["admin"]} />
       <ProtectedRoute path="/admin/tickets" component={AdminTicketsPage} allowedRoles={["admin"]} />
 
       {/* Fallback to 404 */}

--- a/client/src/hooks/use-strikes.tsx
+++ b/client/src/hooks/use-strikes.tsx
@@ -1,0 +1,26 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { apiRequest } from "@/lib/queryClient";
+import { UserStrike } from "@shared/schema";
+
+export function useStrikes() {
+  return useQuery<any[]>({ queryKey: ["/api/strikes"] });
+}
+
+export function useUserStrikes(userId: number) {
+  return useQuery<UserStrike[]>({
+    queryKey: ["/api/users/" + userId + "/strikes"],
+    enabled: !!userId,
+  });
+}
+
+export function useCreateStrike() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (data: { userId: number; reason: string }) =>
+      apiRequest("POST", "/api/strikes", data).then(r => r.json()),
+    onSuccess: (_res, variables) => {
+      qc.invalidateQueries({ queryKey: ["/api/strikes"] });
+      qc.invalidateQueries({ queryKey: ["/api/users/" + variables.userId + "/strikes"] });
+    },
+  });
+}

--- a/client/src/pages/admin/dashboard.tsx
+++ b/client/src/pages/admin/dashboard.tsx
@@ -31,7 +31,8 @@ import {
   Package,
   Star,
   DollarSign,
-  Mail
+  Mail,
+  AlertTriangle
 } from "lucide-react";
 import { useAuth } from "@/hooks/use-auth";
 import { formatCurrency, calculateOrderCommission } from "@/lib/utils";
@@ -179,6 +180,12 @@ export default function AdminDashboard() {
               <Button variant="outline" className="flex items-center">
                 <Mail className="mr-2 h-4 w-4" />
                 Email Templates
+              </Button>
+            </Link>
+            <Link href="/admin/strikes">
+              <Button variant="outline" className="flex items-center">
+                <AlertTriangle className="mr-2 h-4 w-4" />
+                Strikes
               </Button>
             </Link>
           </div>

--- a/client/src/pages/admin/strikes.tsx
+++ b/client/src/pages/admin/strikes.tsx
@@ -1,0 +1,107 @@
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import Header from "@/components/layout/header";
+import Footer from "@/components/layout/footer";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Table, TableHeader, TableRow, TableHead, TableBody, TableCell } from "@/components/ui/table";
+import { Button } from "@/components/ui/button";
+import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from "@/components/ui/select";
+import { useStrikes, useCreateStrike } from "@/hooks/use-strikes";
+import { User } from "@shared/schema";
+
+export default function AdminStrikesPage() {
+  const { data: strikes = [] } = useStrikes();
+  const { data: users = [] } = useQuery<User[]>({ queryKey: ["/api/users"] });
+  const create = useCreateStrike();
+
+  const [selectedUser, setSelectedUser] = useState("");
+  const [reason, setReason] = useState("late/missed shipment");
+
+  const reasonOptions = [
+    "late/missed shipment",
+    "not paying the wire",
+    "sharing contact info",
+    "inaccurate listing/shipping information",
+  ];
+
+  function submit() {
+    if (!selectedUser) return;
+    create.mutate({ userId: Number(selectedUser), reason });
+  }
+
+  return (
+    <>
+      <Header />
+      <main className="max-w-7xl mx-auto px-4 py-8 space-y-6">
+        <Card>
+          <CardHeader>
+            <CardTitle>Issue Strike</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            <Select value={selectedUser} onValueChange={setSelectedUser}>
+              <SelectTrigger className="w-[300px]">
+                <SelectValue placeholder="Select user" />
+              </SelectTrigger>
+              <SelectContent>
+                {users.map(u => (
+                  <SelectItem key={u.id} value={String(u.id)}>
+                    {u.firstName} {u.lastName} ({u.email})
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <Select value={reason} onValueChange={setReason}>
+              <SelectTrigger className="w-[300px]">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {reasonOptions.map(r => (
+                  <SelectItem key={r} value={r}>{r}</SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <Button onClick={submit} disabled={create.isPending || !selectedUser}>
+              Add Strike
+            </Button>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>All Strikes</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>User</TableHead>
+                  <TableHead>Reason</TableHead>
+                  <TableHead>Date</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {strikes.map(s => (
+                  <TableRow key={s.id}>
+                    <TableCell>
+                      {s.first_name ? `${s.first_name} ${s.last_name}` : `User #${s.user_id}`}
+                    </TableCell>
+                    <TableCell>{s.reason}</TableCell>
+                    <TableCell>{new Date(s.created_at).toLocaleDateString()}</TableCell>
+                  </TableRow>
+                ))}
+                {strikes.length === 0 && (
+                  <TableRow>
+                    <TableCell colSpan={3} className="text-center text-gray-500">
+                      No strikes
+                    </TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+      </main>
+      <Footer />
+    </>
+  );
+}

--- a/server/email.ts
+++ b/server/email.ts
@@ -511,6 +511,26 @@ export async function sendSuspensionEmail(to: string, days: number) {
   }
 }
 
+export async function sendStrikeEmail(to: string, reason: string) {
+  if (!transporter) {
+    console.warn("Email transport not configured; skipping strike email");
+    return;
+  }
+
+  const mailOptions = {
+    from: process.env.SMTP_FROM || user,
+    to,
+    subject: "Account Strike Issued",
+    text: `You have received a strike for: ${reason}`,
+  } as nodemailer.SendMailOptions;
+
+  try {
+    await transporter.sendMail(mailOptions);
+  } catch (err) {
+    console.error("Failed to send strike email", err);
+  }
+}
+
 export async function sendAdminUserEmail(
   to: string,
   subject: string,

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -16,6 +16,7 @@ import {
   sendWireReminderEmail,
   sendSellerPayoutEmail,
   sendSupportTicketEmail,
+  sendStrikeEmail,
 } from "./email";
 import { generateInvoicePdf, generateSalesReportPdf } from "./pdf";
 import {
@@ -2085,6 +2086,51 @@ export async function registerRoutes(app: Express): Promise<Server> {
       handleApiError(res, error);
     }
   });
+
+  // Strike routes
+  app.get("/api/strikes", isAuthenticated, isAdmin, async (_req, res) => {
+    try {
+      const strikes = await storage.getAllStrikes();
+      res.json(strikes);
+    } catch (error) {
+      handleApiError(res, error);
+    }
+  });
+
+  app.post("/api/strikes", isAuthenticated, isAdmin, async (req, res) => {
+    try {
+      const { userId, reason } = req.body as { userId: number; reason: string };
+      if (!userId || !reason) {
+        return res.status(400).json({ message: "Missing userId or reason" });
+      }
+      const user = await storage.getUser(Number(userId));
+      if (!user) return res.status(404).json({ message: "User not found" });
+
+      const strike = await storage.createUserStrike({ userId: Number(userId), reason });
+      await sendStrikeEmail(user.email, reason);
+      res.status(201).json(strike);
+    } catch (error) {
+      handleApiError(res, error);
+    }
+  });
+
+  app.get(
+    "/api/users/:id/strikes",
+    isAuthenticated,
+    isAdmin,
+    async (req, res) => {
+      try {
+        const id = parseInt(req.params.id, 10);
+        if (Number.isNaN(id)) {
+          return res.status(400).json({ message: "Invalid user ID" });
+        }
+        const strikes = await storage.getUserStrikes(id);
+        res.json(strikes);
+      } catch (error) {
+        handleApiError(res, error);
+      }
+    },
+  );
 
   // Support ticket routes
   app.get("/api/support-tickets", isAuthenticated, async (req, res) => {

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -450,6 +450,23 @@ export const insertNotificationSchema = createInsertSchema(notifications).omit({
   createdAt: true,
 });
 
+// Strikes issued by admins to buyers or sellers
+export const userStrikes = pgTable("user_strikes", {
+  id: serial("id").primaryKey(),
+  userId: integer("user_id").notNull(),
+  reason: text("reason").notNull(),
+  createdAt: timestamp("created_at").defaultNow(),
+});
+
+export const userStrikesRelations = relations(userStrikes, ({ one }) => ({
+  user: one(users, { fields: [userStrikes.userId], references: [users.id] }),
+}));
+
+export const insertUserStrikeSchema = createInsertSchema(userStrikes).omit({
+  id: true,
+  createdAt: true,
+});
+
 // Site-wide settings key/value store
 export const siteSettings = pgTable("site_settings", {
   key: text("key").primaryKey(),
@@ -500,6 +517,9 @@ export type InsertSupportTicketMessage = z.infer<typeof insertSupportTicketMessa
 
 export type Notification = typeof notifications.$inferSelect;
 export type InsertNotification = z.infer<typeof insertNotificationSchema>;
+
+export type UserStrike = typeof userStrikes.$inferSelect;
+export type InsertUserStrike = z.infer<typeof insertUserStrikeSchema>;
 
 export type EmailTemplate = typeof emailTemplates.$inferSelect;
 export type InsertEmailTemplate = z.infer<typeof insertEmailTemplateSchema>;


### PR DESCRIPTION
## Summary
- add `user_strikes` table and types
- add storage methods and API routes to manage strikes
- send emails when strikes are issued
- create React hooks and admin page to issue strikes
- link to the strikes page from the admin dashboard
- register the strikes route in the app router

## Testing
- `npm run check` *(fails: Cannot find module due to environment)*
- `./test_product_creation.sh` *(fails: server not running)*

------
https://chatgpt.com/codex/tasks/task_e_686fd9e7d0508330a269250d1d9a2b8b