### PR TITLE
Improve strike management and alert emails

### DIFF
--- a/server/email.ts
+++ b/server/email.ts
@@ -439,12 +439,33 @@ export async function sendAdminAlertEmail(subject: string, body: string) {
     return;
   }
 
+  const html = `<!DOCTYPE html>
+  <html lang="en">
+    <head>
+      <meta charset="UTF-8" />
+      <title>${subject}</title>
+    </head>
+    <body style="margin:0;padding:20px;background:#f7f7f7;font-family:Arial,sans-serif;">
+      <table width="100%" cellpadding="0" cellspacing="0" style="max-width:600px;margin:auto;background:#ffffff;border-radius:8px;overflow:hidden;box-shadow:0 0 10px rgba(0,0,0,0.1);">
+        <tr>
+          <td style="background:#222;padding:20px;text-align:center;color:#ffffff;">
+            <h1 style="margin:0;font-size:20px;">${subject}</h1>
+          </td>
+        </tr>
+        <tr>
+          <td style="padding:20px;">${body.replace(/\n/g, '<br>')}</td>
+        </tr>
+      </table>
+    </body>
+  </html>`;
+
   const mailOptions = {
     from: process.env.SMTP_FROM || user,
     to: admin,
     subject,
     text: body,
-  };
+    html,
+  } as nodemailer.SendMailOptions;
 
   try {
     await transporter.sendMail(mailOptions);

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -177,7 +177,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       if (containsContactInfo(req.body.question)) {
         await sendAdminAlertEmail(
           "Blocked contact info in product question",
-          `User #${user.id} attempted to share contact info in a question for product #${id}.\n\n${req.body.question}`
+          `${user.firstName} ${user.lastName} (${user.email}) attempted to share contact info with ${seller.firstName} ${seller.lastName} (${seller.email}) in question for product "${product.title}".\n\n${req.body.question}`
         );
         return res.status(400).json({ message: "Sharing contact information is not allowed" });
       }
@@ -752,7 +752,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       if (containsContactInfo(req.body.message)) {
         await sendAdminAlertEmail(
           "Blocked contact info in order message",
-          `User #${user.id} attempted to share contact info with user #${receiverId} in order #${order.code}.\n\n${req.body.message}`
+          `${user.firstName} ${user.lastName} (${user.email}) attempted to share contact info with ${receiver.firstName} ${receiver.lastName} (${receiver.email}) in order #${order.code}.\n\n${req.body.message}`
         );
         return res.status(400).json({ message: "Sharing contact information is not allowed" });
       }
@@ -816,7 +816,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       if (containsContactInfo(req.body.message)) {
         await sendAdminAlertEmail(
           "Blocked contact info in conversation",
-          `User #${user.id} attempted to share contact info with user #${otherId} in a conversation.\n\n${req.body.message}`
+          `${user.firstName} ${user.lastName} (${user.email}) attempted to share contact info with ${receiver.firstName} ${receiver.lastName} (${receiver.email}) in a conversation.\n\n${req.body.message}`
         );
         return res.status(400).json({ message: "Sharing contact information is not allowed" });
       }

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -822,7 +822,7 @@ export class DatabaseStorage implements IStorage {
   async getAllStrikes(): Promise<any[]> {
     const result = await pool.query(
       `SELECT s.id, s.user_id, s.reason, s.created_at,
-              u.first_name, u.last_name, u.email
+              u.first_name, u.last_name, u.email, u.suspended_until
          FROM user_strikes s
          JOIN users u ON u.id = s.user_id
         ORDER BY s.created_at DESC`,


### PR DESCRIPTION
## Summary
- include suspension status in `getAllStrikes`
- display user email on admin strike page and add Unsuspend action
- show selected user's email when issuing a strike
- improve admin alerts for blocked contact info with names, emails and product title
- send admin alert emails with basic HTML formatting

## Testing
- `npm run check` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686fe5cd61148330bf50e953ac8cd5b5