### PR TITLE
Implement customizable strike emails

### DIFF
--- a/client/src/hooks/use-strike-reasons.tsx
+++ b/client/src/hooks/use-strike-reasons.tsx
@@ -1,0 +1,33 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { StrikeReason } from "@shared/schema";
+import { apiRequest } from "@/lib/queryClient";
+
+export function useStrikeReasons() {
+  return useQuery<StrikeReason[]>({ queryKey: ["/api/admin/strike-reasons"] });
+}
+
+export function useCreateStrikeReason() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (data: { name: string; emailBody: string }) =>
+      apiRequest("POST", "/api/admin/strike-reasons", data).then(r => r.json()),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["/api/admin/strike-reasons"] }),
+  });
+}
+
+export function useUpdateStrikeReason() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (data: { id: number; values: Partial<StrikeReason> }) =>
+      apiRequest("PUT", `/api/admin/strike-reasons/${data.id}`, data.values).then(r => r.json()),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["/api/admin/strike-reasons"] }),
+  });
+}
+
+export function useDeleteStrikeReason() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: number) => apiRequest("DELETE", `/api/admin/strike-reasons/${id}`),
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["/api/admin/strike-reasons"] }),
+  });
+}

--- a/client/src/pages/admin/strikes.tsx
+++ b/client/src/pages/admin/strikes.tsx
@@ -1,10 +1,12 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import Header from "@/components/layout/header";
 import Footer from "@/components/layout/footer";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Table, TableHeader, TableRow, TableHead, TableBody, TableCell } from "@/components/ui/table";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
 import {
   Select,
   SelectTrigger,
@@ -13,6 +15,12 @@ import {
   SelectItem,
 } from "@/components/ui/select";
 import { useStrikes, useCreateStrike, useUserStrikes } from "@/hooks/use-strikes";
+import {
+  useStrikeReasons,
+  useCreateStrikeReason,
+  useUpdateStrikeReason,
+  useDeleteStrikeReason,
+} from "@/hooks/use-strike-reasons";
 import { apiRequest } from "@/lib/queryClient";
 import { User } from "@shared/schema";
 
@@ -28,29 +36,75 @@ export default function AdminStrikesPage() {
     },
   });
 
+  const { data: reasons = [] } = useStrikeReasons();
+  const createReason = useCreateStrikeReason();
+  const updateReason = useUpdateStrikeReason();
+  const deleteReason = useDeleteStrikeReason();
+
   const [selectedUser, setSelectedUser] = useState<number>();
   const [search, setSearch] = useState("");
-  const [reason, setReason] = useState("late/missed shipment");
+  const [reasonId, setReasonId] = useState<number>();
+  const [message, setMessage] = useState("");
+  const [newReasonName, setNewReasonName] = useState("");
+  const [newReasonBody, setNewReasonBody] = useState("");
+  const [editingId, setEditingId] = useState<number | null>(null);
 
-  const reasonOptions = [
-    "late/missed shipment",
-    "not paying the wire",
-    "sharing contact info",
-    "inaccurate listing/shipping information",
-  ];
+  useEffect(() => {
+    if (reasons.length > 0 && reasonId === undefined) {
+      setReasonId(reasons[0].id);
+      setMessage(reasons[0].emailBody);
+    }
+  }, [reasons]);
+
+  useEffect(() => {
+    const r = reasons.find(r => r.id === reasonId);
+    if (r) setMessage(r.emailBody);
+  }, [reasonId, reasons]);
 
   const { data: userStrikes = [] } = useUserStrikes(selectedUser ?? 0);
   const [suspensionDays, setSuspensionDays] = useState<string>("");
   const [permanent, setPermanent] = useState(false);
 
+  function buildPreview() {
+    const r = reasons.find(t => t.id === reasonId);
+    const count = (userStrikes?.length || 0) + 1;
+    const consequences =
+      count === 1
+        ? "This is a warning."
+        : count === 2
+        ? "Further violations may lead to suspension or removal."
+        : "Your account is at risk of permanent suspension.";
+    const days = Number(suspensionDays);
+    const suspensionText = permanent
+      ? "Your account has been suspended permanently."
+      : days > 0
+      ? `Your account has been suspended for ${days} day${days === 1 ? "" : "s"}.`
+      : "";
+    return `<!DOCTYPE html><html><body style="margin:0;padding:20px;background:#f7f7f7;font-family:Arial,sans-serif;"><table width="100%" cellpadding="0" cellspacing="0" style="max-width:600px;margin:auto;background:#ffffff;border-radius:8px;overflow:hidden;box-shadow:0 0 10px rgba(0,0,0,0.1);"><tr><td style="background:#222;padding:20px;text-align:center;"><h1 style="margin:0;color:#ffffff;font-size:24px;">SY Closeouts</h1><p style="margin:5px 0 0;color:#bbbbbb;">Account Strike Notice</p></td></tr><tr><td style="padding:20px;"><p style="margin-top:0;">You have received a strike for the following reason:</p><p style="font-weight:bold;">${r?.name || ""}</p>${message ? `<p>${message}</p>` : ""}<p>This is strike <strong>${count}</strong> of 3 on your account.</p><p>${consequences}</p>${suspensionText ? `<p>${suspensionText}</p>` : ""}</td></tr><tr><td style="background:#f9f9f9;padding:20px;"><p style="margin:0;">If you have questions please reply to this email.</p><p style="margin:5px 0 0;">Thank you for using <strong>SY Closeouts</strong>.</p></td></tr></table></body></html>`;
+  }
+
   function submit() {
     if (!selectedUser) return;
+    const r = reasons.find(t => t.id === reasonId);
+    if (!r) return;
     create.mutate({
       userId: selectedUser,
-      reason,
+      reason: r.name,
+      message,
       suspensionDays: suspensionDays ? Number(suspensionDays) : undefined,
       permanent,
     });
+  }
+
+  function saveReason() {
+    if (editingId) {
+      updateReason.mutate({ id: editingId, values: { name: newReasonName, emailBody: newReasonBody } });
+    } else {
+      createReason.mutate({ name: newReasonName, emailBody: newReasonBody });
+    }
+    setEditingId(null);
+    setNewReasonName("");
+    setNewReasonBody("");
   }
 
   return (
@@ -96,16 +150,28 @@ export default function AdminStrikesPage() {
                 {users.find(u => u.id === selectedUser)?.lastName} ({users.find(u => u.id === selectedUser)?.email}) - {userStrikes.length} strike{userStrikes.length === 1 ? "" : "s"}
               </div>
             )}
-            <Select value={reason} onValueChange={setReason}>
+            <Select value={reasonId?.toString()} onValueChange={v => setReasonId(Number(v))}>
               <SelectTrigger className="w-[300px]">
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
-                {reasonOptions.map(r => (
-                  <SelectItem key={r} value={r}>{r}</SelectItem>
+                {reasons.map(r => (
+                  <SelectItem key={r.id} value={r.id.toString()}>{r.name}</SelectItem>
                 ))}
               </SelectContent>
             </Select>
+            <Textarea rows={4} value={message} onChange={e => setMessage(e.target.value)} />
+            <Button
+              variant="outline"
+              onClick={() => reasonId && updateReason.mutate({ id: reasonId, values: { emailBody: message } })}
+              disabled={!reasonId || updateReason.isPending}
+            >
+              Save Template
+            </Button>
+            <div
+              className="border rounded p-4"
+              dangerouslySetInnerHTML={{ __html: buildPreview() }}
+            />
             {selectedUser && (
               <div className="flex items-center gap-2">
                 <input
@@ -176,6 +242,51 @@ export default function AdminStrikesPage() {
                     </TableCell>
                   </TableRow>
                 )}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Manage Strike Reasons</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            <Input
+              placeholder="Reason name"
+              value={newReasonName}
+              onChange={e => setNewReasonName(e.target.value)}
+            />
+            <Textarea
+              rows={4}
+              placeholder="Email message"
+              value={newReasonBody}
+              onChange={e => setNewReasonBody(e.target.value)}
+            />
+            <Button onClick={saveReason} disabled={createReason.isPending}>
+              Save
+            </Button>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Name</TableHead>
+                  <TableHead>Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {reasons.map(r => (
+                  <TableRow key={r.id}>
+                    <TableCell>{r.name}</TableCell>
+                    <TableCell className="space-x-2">
+                      <Button size="sm" variant="outline" onClick={() => {setNewReasonName(r.name); setNewReasonBody(r.emailBody); setEditingId(r.id);}}>
+                        Edit
+                      </Button>
+                      <Button size="sm" variant="outline" onClick={() => deleteReason.mutate(r.id)}>
+                        Delete
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                ))}
               </TableBody>
             </Table>
           </CardContent>

--- a/server/email.ts
+++ b/server/email.ts
@@ -542,6 +542,7 @@ export async function sendStrikeEmail(
   count: number,
   suspensionDays?: number,
   permanent?: boolean,
+  message?: string,
 ) {
   if (!transporter) {
     console.warn("Email transport not configured; skipping strike email");
@@ -582,6 +583,7 @@ export async function sendStrikeEmail(
           <td style="padding:20px;">
             <p style="margin-top:0;">You have received a strike for the following reason:</p>
             <p style="font-weight:bold;">${reason}</p>
+            ${message ? `<p>${message}</p>` : ""}
             <p>This is strike <strong>${count}</strong> of 3 on your account.</p>
             <p>${consequences}</p>
             ${suspensionText ? `<p>${suspensionText}</p>` : ""}
@@ -600,6 +602,7 @@ export async function sendStrikeEmail(
   const logo = await getLogoAttachment();
   const text =
     `You have received a strike for: ${reason}\n` +
+    (message ? `${message}\n` : "") +
     `Strike ${count} of 3. ${consequences}` +
     (suspensionText ? `\n${suspensionText}` : "");
 

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -26,6 +26,7 @@ import {
   insertSellerApplicationSchema,
   insertSupportTicketSchema,
   insertEmailTemplateSchema,
+  insertStrikeReasonSchema,
   insertOfferSchema,
   offers as offersTable,
   orders as ordersTable,
@@ -991,6 +992,49 @@ export async function registerRoutes(app: Express): Promise<Server> {
           .replace(/\[company\]/gi, u.company || "");
         await sendHtmlEmail(u.email, template.subject, html);
       }
+      res.sendStatus(204);
+    } catch (error) {
+      handleApiError(res, error);
+    }
+  });
+
+  // Strike reason routes
+  app.get("/api/admin/strike-reasons", isAuthenticated, isAdmin, async (_req, res) => {
+    try {
+      const reasons = await storage.getStrikeReasons();
+      res.json(reasons);
+    } catch (error) {
+      handleApiError(res, error);
+    }
+  });
+
+  app.post("/api/admin/strike-reasons", isAuthenticated, isAdmin, async (req, res) => {
+    try {
+      const data = insertStrikeReasonSchema.parse(req.body);
+      const reason = await storage.createStrikeReason(data);
+      res.status(201).json(reason);
+    } catch (error) {
+      handleApiError(res, error);
+    }
+  });
+
+  app.put("/api/admin/strike-reasons/:id", isAuthenticated, isAdmin, async (req, res) => {
+    try {
+      const id = parseInt(req.params.id, 10);
+      if (Number.isNaN(id)) return res.status(400).json({ message: "Invalid reason ID" });
+      const reason = await storage.updateStrikeReason(id, req.body);
+      if (!reason) return res.status(404).json({ message: "Reason not found" });
+      res.json(reason);
+    } catch (error) {
+      handleApiError(res, error);
+    }
+  });
+
+  app.delete("/api/admin/strike-reasons/:id", isAuthenticated, isAdmin, async (req, res) => {
+    try {
+      const id = parseInt(req.params.id, 10);
+      if (Number.isNaN(id)) return res.status(400).json({ message: "Invalid reason ID" });
+      await storage.deleteStrikeReason(id);
       res.sendStatus(204);
     } catch (error) {
       handleApiError(res, error);
@@ -2099,9 +2143,10 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
   app.post("/api/strikes", isAuthenticated, isAdmin, async (req, res) => {
     try {
-      const { userId, reason, suspensionDays, permanent } = req.body as {
+      const { userId, reason, message, suspensionDays, permanent } = req.body as {
         userId: number;
         reason: string;
+        message?: string;
         suspensionDays?: number;
         permanent?: boolean;
       };
@@ -2126,7 +2171,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
         await sendSuspensionEmail(user.email, suspensionDays);
       }
 
-      await sendStrikeEmail(user.email, reason, strikeNumber, suspensionDays, permanent);
+      await sendStrikeEmail(user.email, reason, strikeNumber, suspensionDays, permanent, message);
       res.status(201).json(strike);
     } catch (error) {
       handleApiError(res, error);

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -14,7 +14,8 @@ import {
   notifications, Notification, InsertNotification,
   emailTemplates, EmailTemplate, InsertEmailTemplate,
   siteSettings,
-  userStrikes, UserStrike, InsertUserStrike
+  userStrikes, UserStrike, InsertUserStrike,
+  strikeReasons, StrikeReason, InsertStrikeReason
 } from "@shared/schema";
 import session from "express-session";
 import { db, pool } from "./db";
@@ -122,6 +123,13 @@ export interface IStorage {
   createEmailTemplate(t: InsertEmailTemplate): Promise<EmailTemplate>;
   updateEmailTemplate(id: number, t: Partial<EmailTemplate>): Promise<EmailTemplate | undefined>;
   deleteEmailTemplate(id: number): Promise<void>;
+
+  // Strike reason methods
+  getStrikeReasons(): Promise<StrikeReason[]>;
+  getStrikeReason(id: number): Promise<StrikeReason | undefined>;
+  createStrikeReason(reason: InsertStrikeReason): Promise<StrikeReason>;
+  updateStrikeReason(id: number, reason: Partial<StrikeReason>): Promise<StrikeReason | undefined>;
+  deleteStrikeReason(id: number): Promise<void>;
 
   // Strike methods
   getAllStrikes(): Promise<any[]>;
@@ -816,6 +824,34 @@ export class DatabaseStorage implements IStorage {
 
   async deleteEmailTemplate(id: number): Promise<void> {
     await db.delete(emailTemplates).where(eq(emailTemplates.id, id));
+  }
+
+  // Strike reason methods
+  async getStrikeReasons(): Promise<StrikeReason[]> {
+    return await db.select().from(strikeReasons).orderBy(desc(strikeReasons.createdAt));
+  }
+
+  async getStrikeReason(id: number): Promise<StrikeReason | undefined> {
+    const [r] = await db.select().from(strikeReasons).where(eq(strikeReasons.id, id));
+    return r;
+  }
+
+  async createStrikeReason(reason: InsertStrikeReason): Promise<StrikeReason> {
+    const [r] = await db.insert(strikeReasons).values(reason).returning();
+    return r;
+  }
+
+  async updateStrikeReason(id: number, reason: Partial<StrikeReason>): Promise<StrikeReason | undefined> {
+    const [r] = await db
+      .update(strikeReasons)
+      .set(reason)
+      .where(eq(strikeReasons.id, id))
+      .returning();
+    return r;
+  }
+
+  async deleteStrikeReason(id: number): Promise<void> {
+    await db.delete(strikeReasons).where(eq(strikeReasons.id, id));
   }
 
   // Strike methods

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -467,6 +467,19 @@ export const insertUserStrikeSchema = createInsertSchema(userStrikes).omit({
   createdAt: true,
 });
 
+// Predefined strike reasons with custom email text
+export const strikeReasons = pgTable("strike_reasons", {
+  id: serial("id").primaryKey(),
+  name: text("name").notNull(),
+  emailBody: text("email_body").notNull(),
+  createdAt: timestamp("created_at").defaultNow(),
+});
+
+export const insertStrikeReasonSchema = createInsertSchema(strikeReasons).omit({
+  id: true,
+  createdAt: true,
+});
+
 // Site-wide settings key/value store
 export const siteSettings = pgTable("site_settings", {
   key: text("key").primaryKey(),
@@ -520,6 +533,9 @@ export type InsertNotification = z.infer<typeof insertNotificationSchema>;
 
 export type UserStrike = typeof userStrikes.$inferSelect;
 export type InsertUserStrike = z.infer<typeof insertUserStrikeSchema>;
+
+export type StrikeReason = typeof strikeReasons.$inferSelect;
+export type InsertStrikeReason = z.infer<typeof insertStrikeReasonSchema>;
 
 export type EmailTemplate = typeof emailTemplates.$inferSelect;
 export type InsertEmailTemplate = z.infer<typeof insertEmailTemplateSchema>;


### PR DESCRIPTION
## Summary
- store reusable strike reasons
- expose CRUD API endpoints for strike reasons
- include optional custom message in strike emails
- add React hooks for strike reason management
- update admin strike page with email preview and template editing

## Testing
- `npm run check` *(fails: Cannot download deps)*

------
https://chatgpt.com/codex/tasks/task_e_686fe9a6d18883309eec1eb9f3588241