### PR TITLE
Add user-targeted email templates

### DIFF
--- a/server/email.ts
+++ b/server/email.ts
@@ -627,6 +627,7 @@ export async function sendAdminUserEmail(
   to: string,
   subject: string,
   body: string,
+  html?: string,
 ) {
   if (!transporter) {
     console.warn("Email transport not configured; skipping admin user email");
@@ -638,7 +639,8 @@ export async function sendAdminUserEmail(
     to,
     subject,
     text: body,
-  };
+    ...(html ? { html } : {}),
+  } as nodemailer.SendMailOptions;
 
   try {
     await transporter.sendMail(mailOptions);

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -971,12 +971,12 @@ export async function registerRoutes(app: Express): Promise<Server> {
           return res.status(404).json({ message: "User not found" });
         }
 
-        const { subject, message } = req.body;
+        const { subject, message, html } = req.body;
         if (!subject || !message) {
           return res.status(400).json({ message: "Missing subject or message" });
         }
 
-        await sendAdminUserEmail(user.email, subject, message);
+        await sendAdminUserEmail(user.email, subject, message, html);
         res.sendStatus(204);
       } catch (error) {
         handleApiError(res, error);


### PR DESCRIPTION
## Summary
- revamp admin email templates page to match the strike page layout
- allow selecting multiple users and previewing template with placeholders
- implement `{{{name}}}` etc. placeholder replacement for previews and sending
- support HTML emails when sending to a specific user

## Testing
- `npm run check` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_686ff8f193a883308dc71517d85c67a3