### PR TITLE
Add strike candidate listing

### DIFF
--- a/client/src/hooks/use-strikes.tsx
+++ b/client/src/hooks/use-strikes.tsx
@@ -30,3 +30,7 @@ export function useCreateStrike() {
     },
   });
 }
+
+export function useStrikeCandidates() {
+  return useQuery<any[]>({ queryKey: ["/api/admin/strike-candidates"] });
+}

--- a/client/src/pages/admin/strikes.tsx
+++ b/client/src/pages/admin/strikes.tsx
@@ -14,7 +14,7 @@ import {
   SelectContent,
   SelectItem,
 } from "@/components/ui/select";
-import { useStrikes, useCreateStrike, useUserStrikes } from "@/hooks/use-strikes";
+import { useStrikes, useCreateStrike, useUserStrikes, useStrikeCandidates } from "@/hooks/use-strikes";
 import {
   useStrikeReasons,
   useCreateStrikeReason,
@@ -37,6 +37,7 @@ export default function AdminStrikesPage() {
   });
 
   const { data: reasons = [] } = useStrikeReasons();
+  const { data: candidates = [] } = useStrikeCandidates();
   const createReason = useCreateStrikeReason();
   const updateReason = useUpdateStrikeReason();
   const deleteReason = useDeleteStrikeReason();
@@ -274,6 +275,39 @@ export default function AdminStrikesPage() {
                   <TableRow>
                     <TableCell colSpan={5} className="text-center text-gray-500">
                       No strikes
+                    </TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Strike Candidates</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>User</TableHead>
+                  <TableHead>Email</TableHead>
+                  <TableHead>Reasons</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {candidates.map(c => (
+                  <TableRow key={c.userId}>
+                    <TableCell>{c.firstName} {c.lastName}</TableCell>
+                    <TableCell>{c.email}</TableCell>
+                    <TableCell>{c.reasons.join(', ')}</TableCell>
+                  </TableRow>
+                ))}
+                {candidates.length === 0 && (
+                  <TableRow>
+                    <TableCell colSpan={3} className="text-center text-gray-500">
+                      No candidates
                     </TableCell>
                   </TableRow>
                 )}


### PR DESCRIPTION
## Summary
- surface potential strike candidates in admin
- expose `useStrikeCandidates` hook
- add API endpoint `/api/admin/strike-candidates`
- expand storage with helpers to query recent messages and questions

## Testing
- `npm run check` *(fails: Cannot find module)*

------
https://chatgpt.com/codex/tasks/task_e_686ffa5878b083309776ee3f6fa78717