### PR TITLE
Improve address validation and display full addresses

### DIFF
--- a/client/src/hooks/use-auth.tsx
+++ b/client/src/hooks/use-auth.tsx
@@ -24,10 +24,18 @@ export const registerSchemaBase = z.object({
   lastName: z.string().min(1, "Last name is required"),
   company: z.string().optional(),
   phone: z.string().min(1, "Phone is required"),
-  address: z.string().min(1, "Address is required"),
+  address: z
+    .string()
+    .min(1, "Address is required")
+    .refine((val) => /\d/.test(val) && /[A-Za-z]/.test(val) && val.length >= 5, {
+      message: "Please enter a valid street address",
+    }),
   city: z.string().min(1, "City is required"),
   state: z.string().min(1, "State is required"),
-  zipCode: z.string().min(1, "ZIP code is required"),
+  zipCode: z
+    .string()
+    .min(1, "ZIP code is required")
+    .regex(/^\d{5}(?:-\d{4})?$/, "Please enter a valid ZIP code"),
   country: z.string().default("United States"),
   role: z.string().default("buyer"),
   resaleCertUrl: z.string().optional().default(""),

--- a/client/src/pages/buyer/profile.tsx
+++ b/client/src/pages/buyer/profile.tsx
@@ -97,7 +97,7 @@ export default function BuyerProfilePage() {
                     <div key={addr.id} className="flex items-start space-x-2 border rounded-md p-4">
                       <RadioGroupItem value={String(addr.id)} id={`addr-${addr.id}`} />
                       <label htmlFor={`addr-${addr.id}`} className="text-sm leading-none cursor-pointer">
-                        {addr.name} - {addr.address}, {addr.city}
+                        {addr.name} - {addr.address}, {addr.city}, {addr.state} {addr.zipCode}
                       </label>
                     </div>
                   ))}

--- a/client/src/pages/buyer/signup.tsx
+++ b/client/src/pages/buyer/signup.tsx
@@ -256,7 +256,7 @@ export default function BuyerSignupPage() {
                         <FormItem>
                           <FormLabel>Street Address</FormLabel>
                           <FormControl>
-                            <Input placeholder="123 Main St" {...field} />
+                            <Input placeholder="123 Main St" autoComplete="street-address" {...field} />
                           </FormControl>
                           <FormMessage />
                         </FormItem>

--- a/client/src/pages/checkout-page.tsx
+++ b/client/src/pages/checkout-page.tsx
@@ -446,7 +446,7 @@ export default function CheckoutPage() {
                     htmlFor={`checkout-addr-${addr.id}`}
                     className="text-sm leading-none cursor-pointer"
                   >
-                    {addr.address}, {addr.city}
+                    {addr.address}, {addr.city}, {addr.state} {addr.zipCode}
                   </label>
                 </div>
               ))}

--- a/client/src/pages/seller/apply.tsx
+++ b/client/src/pages/seller/apply.tsx
@@ -437,7 +437,7 @@ export default function SellerApply() {
                           <FormItem>
                             <FormLabel>Street Address</FormLabel>
                             <FormControl>
-                              <Input placeholder="123 Main St" {...field} />
+                              <Input placeholder="123 Main St" autoComplete="street-address" {...field} />
                             </FormControl>
                             <FormMessage />
                           </FormItem>

--- a/client/src/pages/seller/dashboard.tsx
+++ b/client/src/pages/seller/dashboard.tsx
@@ -876,7 +876,7 @@ export default function SellerDashboard() {
                         <div key={addr.id} className="flex items-start space-x-2 border rounded-md p-4">
                           <RadioGroupItem value={String(addr.id)} id={`seller-addr-${addr.id}`} />
                           <label htmlFor={`seller-addr-${addr.id}`} className="text-sm leading-none cursor-pointer">
-                            {addr.name} - {addr.address}, {addr.city}
+                            {addr.name} - {addr.address}, {addr.city}, {addr.state} {addr.zipCode}
                           </label>
                         </div>
                       ))}

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -6,7 +6,7 @@ import { scrypt, randomBytes, timingSafeEqual } from "crypto";
 import { promisify } from "util";
 import { storage } from "./storage";
 import { sendPasswordResetEmail } from "./email";
-import { User } from "@shared/schema";
+import { User, insertAddressSchema } from "@shared/schema";
 
 declare global {
   namespace Express {
@@ -146,7 +146,7 @@ export function setupAuth(app: Express) {
       });
 
       if (address && city && state && zipCode) {
-        await storage.createAddress({
+        const addrData = insertAddressSchema.parse({
           userId: user.id,
           name: `${user.firstName} ${user.lastName}`,
           company: user.company ?? undefined,
@@ -157,6 +157,7 @@ export function setupAuth(app: Express) {
           country: country || "United States",
           phone,
         });
+        await storage.createAddress(addrData);
       }
 
       await loginAndSaveSession(req, user);

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -28,6 +28,7 @@ import {
   insertSupportTicketSchema,
   insertEmailTemplateSchema,
   insertStrikeReasonSchema,
+  insertAddressSchema,
   insertUserNoteSchema,
   type InsertUserNote,
   insertOfferSchema,
@@ -2165,7 +2166,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
   app.post("/api/addresses", isAuthenticated, async (req, res) => {
     try {
       const user = req.user as Express.User;
-      const address = await storage.createAddress({ ...req.body, userId: user.id });
+      const data = insertAddressSchema.parse({ ...req.body, userId: user.id });
+      const address = await storage.createAddress(data);
       res.status(201).json(address);
     } catch (error) {
       handleApiError(res, error);

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -56,10 +56,23 @@ export const addressesRelations = relations(addresses, ({ one }) => ({
   }),
 }));
 
-export const insertAddressSchema = createInsertSchema(addresses).omit({
-  id: true,
-  createdAt: true,
-});
+export const insertAddressSchema = createInsertSchema(addresses)
+  .omit({
+    id: true,
+    createdAt: true,
+  })
+  .extend({
+    address: z
+      .string()
+      .min(5, "Invalid address")
+      .refine(
+        (val) => /\d/.test(val) && /[A-Za-z]/.test(val),
+        "Invalid address"
+      ),
+    zipCode: z
+      .string()
+      .regex(/^\d{5}(?:-\d{4})?$/, "Invalid ZIP code"),
+  });
 
 // Payment methods schema
 export const paymentMethods = pgTable("payment_methods", {


### PR DESCRIPTION
## Summary
- display full address details everywhere saved addresses are listed
- enable street address autofill on signup forms
- validate address and ZIP code on signup
- use same address validation when registering and creating addresses via API

## Testing
- `npm run check` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_686ffb40f4908330b496441ad928671f