### PR TITLE
Improve admin email UI and track sent emails

### DIFF
--- a/client/src/hooks/use-email-templates.tsx
+++ b/client/src/hooks/use-email-templates.tsx
@@ -1,5 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { EmailTemplate } from "@shared/schema";
+import { EmailTemplate, EmailLog } from "@shared/schema";
 import { apiRequest } from "@/lib/queryClient";
 
 export function useEmailTemplates() {
@@ -38,4 +38,11 @@ export function useSendEmailTemplate() {
   return useMutation((data: { id: number; group: string }) =>
     apiRequest("POST", `/api/admin/email-templates/${data.id}/send`, { group: data.group })
   );
+}
+
+export function useEmailLogs(templateId?: number) {
+  return useQuery<(EmailLog & { user: any })[]>({
+    queryKey: ["/api/admin/email-templates", templateId, "logs"],
+    enabled: !!templateId,
+  });
 }

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -979,6 +979,12 @@ export async function registerRoutes(app: Express): Promise<Server> {
         }
 
         await sendAdminUserEmail(user.email, subject, message, html);
+        await storage.createEmailLog({
+          templateId: req.body.templateId,
+          userId: user.id,
+          subject,
+          html: html || message,
+        });
         res.sendStatus(204);
       } catch (error) {
         handleApiError(res, error);
@@ -1046,8 +1052,25 @@ export async function registerRoutes(app: Express): Promise<Server> {
           .replace(/\[name\]/gi, `${u.firstName} ${u.lastName}`)
           .replace(/\[company\]/gi, u.company || "");
         await sendHtmlEmail(u.email, template.subject, html);
+        await storage.createEmailLog({
+          templateId: template.id,
+          userId: u.id,
+          subject: template.subject,
+          html,
+        });
       }
       res.sendStatus(204);
+    } catch (error) {
+      handleApiError(res, error);
+    }
+  });
+
+  app.get("/api/admin/email-templates/:id/logs", isAuthenticated, isAdmin, async (req, res) => {
+    try {
+      const id = parseInt(req.params.id, 10);
+      if (Number.isNaN(id)) return res.status(400).json({ message: "Invalid template ID" });
+      const logs = await storage.getEmailLogs(id);
+      res.json(logs);
     } catch (error) {
       handleApiError(res, error);
     }

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -13,6 +13,7 @@ import {
   supportTickets, SupportTicket, InsertSupportTicket,
   notifications, Notification, InsertNotification,
   emailTemplates, EmailTemplate, InsertEmailTemplate,
+  emailLogs, EmailLog, InsertEmailLog,
   siteSettings,
   userStrikes, UserStrike, InsertUserStrike,
   strikeReasons, StrikeReason, InsertStrikeReason,
@@ -148,6 +149,10 @@ export interface IStorage {
   // Site setting methods
   getSiteSetting(key: string): Promise<string | undefined>;
   setSiteSetting(key: string, value: string): Promise<void>;
+
+  // Email log methods
+  getEmailLogs(templateId: number): Promise<(EmailLog & { user: User })[]>;
+  createEmailLog(log: InsertEmailLog): Promise<EmailLog>;
   
   // Session store
   sessionStore: session.Store;
@@ -830,6 +835,37 @@ export class DatabaseStorage implements IStorage {
 
   async deleteEmailTemplate(id: number): Promise<void> {
     await db.delete(emailTemplates).where(eq(emailTemplates.id, id));
+  }
+
+  // Email log methods
+  async getEmailLogs(templateId: number): Promise<(EmailLog & { user: User })[]> {
+    const result = await pool.query(
+      `SELECT l.*, u.first_name, u.last_name, u.email
+         FROM email_logs l
+         JOIN users u ON u.id = l.user_id
+        WHERE l.template_id = $1
+        ORDER BY l.created_at DESC`,
+      [templateId],
+    );
+    return result.rows.map((r: any) => ({
+      id: r.id,
+      templateId: r.template_id,
+      userId: r.user_id,
+      subject: r.subject,
+      html: r.html,
+      createdAt: r.created_at,
+      user: {
+        id: r.user_id,
+        firstName: r.first_name,
+        lastName: r.last_name,
+        email: r.email,
+      } as User,
+    }));
+  }
+
+  async createEmailLog(log: InsertEmailLog): Promise<EmailLog> {
+    const [l] = await db.insert(emailLogs).values(log).returning();
+    return l;
   }
 
   // Strike reason methods

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -451,6 +451,33 @@ export const insertNotificationSchema = createInsertSchema(notifications).omit({
   createdAt: true,
 });
 
+// Logs of emails sent using templates
+export const emailLogs = pgTable("email_logs", {
+  id: serial("id").primaryKey(),
+  templateId: integer("template_id")
+    .notNull()
+    .references(() => emailTemplates.id),
+  userId: integer("user_id")
+    .notNull()
+    .references(() => users.id),
+  subject: text("subject").notNull(),
+  html: text("html").notNull(),
+  createdAt: timestamp("created_at").defaultNow(),
+});
+
+export const emailLogsRelations = relations(emailLogs, ({ one }) => ({
+  template: one(emailTemplates, {
+    fields: [emailLogs.templateId],
+    references: [emailTemplates.id],
+  }),
+  user: one(users, { fields: [emailLogs.userId], references: [users.id] }),
+}));
+
+export const insertEmailLogSchema = createInsertSchema(emailLogs).omit({
+  id: true,
+  createdAt: true,
+});
+
 // Strikes issued by admins to buyers or sellers
 export const userStrikes = pgTable("user_strikes", {
   id: serial("id").primaryKey(),
@@ -564,6 +591,9 @@ export type InsertStrikeReason = z.infer<typeof insertStrikeReasonSchema>;
 
 export type EmailTemplate = typeof emailTemplates.$inferSelect;
 export type InsertEmailTemplate = z.infer<typeof insertEmailTemplateSchema>;
+
+export type EmailLog = typeof emailLogs.$inferSelect;
+export type InsertEmailLog = z.infer<typeof insertEmailLogSchema>;
 
 export type SiteSetting = typeof siteSettings.$inferSelect;
 export type InsertSiteSetting = z.infer<typeof insertSiteSettingSchema>;


### PR DESCRIPTION
## Summary
- add `email_logs` table for sent email history
- expose DB helpers and API endpoints for email logs
- wrap admin emails in standard design
- fetch & display sent email history on admin template page
- enhance admin email template UI

## Testing
- `npm run check` *(fails: Cannot find module 'wouter' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_686ffbf9df588330ae3d88f2d2c150c7