### PR TITLE
Add Open Graph tags for products

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -9,6 +9,7 @@
     <meta property="og:title" content="SY Closeouts - B2B Wholesale Marketplace" />
     <meta property="og:description" content="Connect with verified sellers and buy wholesale closeout inventory at great prices." />
     <meta property="og:type" content="website" />
+    <meta property="og:image" content="/generated-icon.png" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -21,7 +21,10 @@ function escapeHtml(str: string) {
     .replace(/'/g, "&#39;");
 }
 
-function injectMeta(template: string, meta: { title?: string; image?: string }) {
+function injectMeta(
+  template: string,
+  meta: { title?: string; image?: string; description?: string; url?: string },
+) {
   if (meta.title) {
     const safeTitle = escapeHtml(meta.title);
     template = template.replace(/<title>.*?<\/title>/, `<title>${safeTitle}<\/title>`);
@@ -29,6 +32,27 @@ function injectMeta(template: string, meta: { title?: string; image?: string }) 
       /<meta property="og:title"[^>]*>/,
       `<meta property="og:title" content="${safeTitle}" />`,
     );
+  }
+  if (meta.description) {
+    const safeDesc = escapeHtml(meta.description);
+    template = template.replace(
+      /<meta property="og:description"[^>]*>/,
+      `<meta property="og:description" content="${safeDesc}" />`,
+    );
+  }
+  if (meta.url) {
+    const safeUrl = escapeHtml(meta.url);
+    if (template.match(/<meta property="og:url"/)) {
+      template = template.replace(
+        /<meta property="og:url"[^>]*>/,
+        `<meta property="og:url" content="${safeUrl}" />`,
+      );
+    } else {
+      template = template.replace(
+        /<meta property="og:type"[^>]*>/,
+        `$&\n    <meta property="og:url" content="${safeUrl}" />`,
+      );
+    }
   }
   if (meta.image) {
     const safeImg = escapeHtml(meta.image);
@@ -102,6 +126,8 @@ export async function setupVite(app: Express, server: Server) {
       template = injectMeta(template, {
         title: product.title,
         image: product.images[0],
+        description: product.description,
+        url: `${req.protocol}://${req.get("host")}${req.originalUrl}`,
       });
       const page = await vite.transformIndexHtml(url, template);
       res.status(200).set({ "Content-Type": "text/html" }).end(page);
@@ -157,6 +183,8 @@ export function serveStatic(app: Express) {
       template = injectMeta(template, {
         title: product.title,
         image: product.images[0],
+        description: product.description,
+        url: `${req.protocol}://${req.get("host")}${req.originalUrl}`,
       });
       res.status(200).set({ "Content-Type": "text/html" }).end(template);
     } catch (e) {


### PR DESCRIPTION
## Summary
- inject dynamic Open Graph metadata for product pages
- include default OG image in `index.html`

## Testing
- `npm run check` *(fails: cannot find module declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6871280fe0248330bc3f1b853ac4f1af