### PR TITLE
Add nginx proxy example

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,13 @@ The invoice and seller notification emails are sent once the order status is upd
 
 ## Support Tickets
 When a user submits a support ticket they receive an email confirming the ticket number. Set `SUPPORT_EMAIL_FROM` to control the "from" address for these messages and `SUPPORT_EMAIL_CC` to copy another address on every ticket email.
+
+## Deploying with Nginx
+The `docs/nginx_proxy.conf` file contains an example Nginx configuration that
+terminates TLS and forwards every request to the Express server. This allows the
+server to inject dynamic Open Graph meta tags for product pages. Copy the file to
+`/etc/nginx/sites-available` (adjusting paths to your certificates) and enable it
+with a symlink in `sites-enabled`.
+
+The Express app serves the built client and all API routes on the same port
+(default `5000`), so Nginx only needs to proxy to `http://localhost:5000`.

--- a/docs/nginx_proxy.conf
+++ b/docs/nginx_proxy.conf
@@ -1,0 +1,26 @@
+server {
+    listen 80;
+    server_name sycloseouts.com www.sycloseouts.com;
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl;
+    server_name sycloseouts.com www.sycloseouts.com;
+
+    ssl_certificate /etc/letsencrypt/live/sycloseouts.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/sycloseouts.com/privkey.pem;
+    include /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+
+    # Forward every request to the Node/Express server so
+    # product pages get dynamic OG metadata injected.
+    location / {
+        proxy_pass http://localhost:5000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_cache_bypass $http_upgrade;
+    }
+}


### PR DESCRIPTION
## Summary
- document running through nginx
- add example nginx config forwarding to Express server

## Testing
- `npm run check` *(fails: cannot find module `wouter` and others)*

------
https://chatgpt.com/codex/tasks/task_e_68712dc7ffa08330840884c4130a6584