### PR TITLE
docs: warn against serving dist directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,41 @@ The invoice and seller notification emails are sent once the order status is upd
 
 ## Support Tickets
 When a user submits a support ticket they receive an email confirming the ticket number. Set `SUPPORT_EMAIL_FROM` to control the "from" address for these messages and `SUPPORT_EMAIL_CC` to copy another address on every ticket email.
+
+## Deploying with Nginx
+The `docs/nginx_proxy.conf` file contains an example Nginx configuration that
+terminates TLS and forwards every request to the Express server. This allows the
+server to inject dynamic Open Graph meta tags for product pages. Copy the file to
+`/etc/nginx/sites-available` (adjusting paths to your certificates) and enable it
+with a symlink in `sites-enabled`.
+
+The Express app serves the built client and all API routes on the same port
+(default `5000`), so Nginx only needs to proxy to `http://localhost:5000`.
+
+Make sure the Express server is running on the port that Nginx forwards to.
+In production you typically build the project and start the compiled server:
+
+```bash
+npm run build
+PORT=5000 npm start
+```
+
+If you use a different port, update the `proxy_pass` line in
+`docs/nginx_proxy.conf` to match. A port mismatch will result in a 502 Bad
+Gateway error.
+
+After editing the Nginx configuration, reload it so the changes take effect:
+
+```bash
+sudo nginx -t && sudo systemctl reload nginx
+```
+
+If you still see a 502, verify the Express server is reachable from Nginx by
+running `curl http://localhost:5000` on the same machine. The command should
+return the HTML for the client. If it fails, ensure the server is running and
+listening on that port.
+
+Avoid configuring Nginx to serve the built `dist` directory directly. If you set
+`root` or `try_files` the Node server never sees the request and the default Open
+Graph tags remain. Use the provided proxy config so every path is handled by the
+Express app and product pages get their dynamic metadata injected.

--- a/docs/nginx_proxy.conf
+++ b/docs/nginx_proxy.conf
@@ -1,0 +1,27 @@
+server {
+    listen 80;
+    server_name sycloseouts.com www.sycloseouts.com;
+    return 301 https://$host$request_uri;
+}
+
+server {
+    listen 443 ssl;
+    server_name sycloseouts.com www.sycloseouts.com;
+
+    ssl_certificate /etc/letsencrypt/live/sycloseouts.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/sycloseouts.com/privkey.pem;
+    include /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+
+    # Forward every request to the Node/Express server so
+    # product pages get dynamic OG metadata injected.
+    # Change the port if your server listens elsewhere.
+    location / {
+        proxy_pass http://localhost:5000;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_cache_bypass $http_upgrade;
+    }
+}


### PR DESCRIPTION
## Summary
- explain that serving built files directly disables dynamic metadata injection

## Testing
- `npm run check` *(fails: missing dependencies and type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68712dc7ffa08330840884c4130a6584