### PR TITLE
Show upload package prompt when buyer handles shipping

### DIFF
--- a/client/src/pages/seller/orders.tsx
+++ b/client/src/pages/seller/orders.tsx
@@ -273,8 +273,14 @@ export default function SellerOrdersPage() {
                         size="sm"
                         onClick={() => handleOpenPackageDetails(order)}
                       >
-                        Upload Package Details
-                        <AlertCircle className="ml-1 h-4 w-4 text-red-500" />
+                        {order.shippingChoice === "buyer" ? (
+                          <>
+                            Upload Package Details
+                            <AlertCircle className="ml-1 h-4 w-4 text-red-500" />
+                          </>
+                        ) : (
+                          "Package Details"
+                        )}
                       </Button>
                       <Button variant="outline" size="sm" asChild>
                         <Link href={`/seller/orders/${order.id}`}>View Details</Link>


### PR DESCRIPTION
## Summary
- only show the *Upload Package Details* text when buyers arrange their own shipping

## Testing
- `npm run check` *(fails: Cannot find module 'wouter' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6873e34e8ae08330a2d15239faa6d0b0