### PR TITLE
Add editable favicon and site title

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -10,6 +10,12 @@
     <meta property="og:description" content="Connect with verified sellers and buy wholesale closeout inventory at great prices." />
     <meta property="og:type" content="website" />
     <meta property="og:image" content="/generated-icon.png" />
+    <link
+      rel="icon"
+      id="site-favicon"
+      href="/generated-icon.png"
+      type="image/png"
+    />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -66,6 +66,15 @@ function SettingsLoader() {
     if (data && data.commissionRate !== undefined) {
       setServiceFeeRate(data.commissionRate);
     }
+    if (data) {
+      document.title = data.siteTitle;
+      const faviconEl = document.getElementById(
+        "site-favicon"
+      ) as HTMLLinkElement | null;
+      if (faviconEl && data.favicon) {
+        faviconEl.href = data.favicon;
+      }
+    }
   }, [data]);
   return null;
 }

--- a/client/src/components/layout/footer-fixed.tsx
+++ b/client/src/components/layout/footer-fixed.tsx
@@ -167,7 +167,7 @@ export default function Footer() {
               </form>
             </div>
             <div className="flex items-center md:justify-end">
-              <p className="text-base text-gray-400">&copy; {new Date().getFullYear()} SY Closeouts. All rights reserved.</p>
+              <p className="text-base text-gray-400">&copy; {new Date().getFullYear()} {settings?.siteTitle ?? 'SY Closeouts'}. All rights reserved.</p>
             </div>
           </div>
         </div>

--- a/client/src/components/layout/footer.tsx
+++ b/client/src/components/layout/footer.tsx
@@ -96,7 +96,7 @@ export default function Footer() {
           </div>
         </div>
         <div className="mt-12 border-t border-gray-700 pt-8">
-          <p className="text-base text-gray-400 text-center">&copy; {new Date().getFullYear()} SY Closeouts. All rights reserved.</p>
+          <p className="text-base text-gray-400 text-center">&copy; {new Date().getFullYear()} {settings?.siteTitle ?? 'SY Closeouts'}. All rights reserved.</p>
         </div>
       </div>
     </footer>

--- a/client/src/components/layout/header-fixed.tsx
+++ b/client/src/components/layout/header-fixed.tsx
@@ -56,7 +56,9 @@ export default function Header() {
                       className="h-full max-h-16 w-auto object-contain"
                     />
                   ) : (
-                    <span className="text-primary font-bold text-2xl cursor-pointer">SY Closeouts</span>
+                    <span className="text-primary font-bold text-2xl cursor-pointer">
+                      {settings?.siteTitle ?? "SY Closeouts"}
+                    </span>
                   )}
                 </Link>
               </div>

--- a/client/src/components/layout/header.tsx
+++ b/client/src/components/layout/header.tsx
@@ -65,7 +65,9 @@ export default function Header({ dashboardTabs, onProfileClick }: HeaderProps) {
                       className="h-full max-h-16 w-auto object-contain"
                     />
                   ) : (
-                    <span className="text-primary font-bold text-2xl cursor-pointer">SY Closeouts</span>
+                    <span className="text-primary font-bold text-2xl cursor-pointer">
+                      {settings?.siteTitle ?? "SY Closeouts"}
+                    </span>
                   )}
                 </Link>
               </div>

--- a/client/src/hooks/use-settings.tsx
+++ b/client/src/hooks/use-settings.tsx
@@ -4,9 +4,13 @@ import { apiRequest } from "@/lib/queryClient";
 export interface SiteSettings {
   commissionRate: number;
   logo?: string | null;
+  siteTitle: string;
+  favicon?: string | null;
 }
 
 export const DEFAULT_SERVICE_FEE_RATE = 0.035;
+export const DEFAULT_SITE_TITLE =
+  "SY Closeouts - B2B Wholesale Liquidation Marketplace";
 
 let serviceFeeRate = DEFAULT_SERVICE_FEE_RATE;
 export function setServiceFeeRate(rate: number) {

--- a/client/src/pages/admin/settings.tsx
+++ b/client/src/pages/admin/settings.tsx
@@ -12,35 +12,62 @@ export default function AdminSettingsPage() {
   const update = useUpdateSettings();
   const [rate, setRate] = useState(0.035);
   const [logo, setLogo] = useState<string | null>(null);
-  const fileRef = useRef<HTMLInputElement | null>(null);
-  const [uploading, setUploading] = useState(false);
+  const [siteTitle, setSiteTitle] = useState("SY Closeouts - B2B Wholesale Liquidation Marketplace");
+  const [favicon, setFavicon] = useState<string | null>(null);
+  const logoFileRef = useRef<HTMLInputElement | null>(null);
+  const faviconFileRef = useRef<HTMLInputElement | null>(null);
+  const [uploadingLogo, setUploadingLogo] = useState(false);
+  const [uploadingFavicon, setUploadingFavicon] = useState(false);
 
   useEffect(() => {
     if (data) {
       setRate(data.commissionRate);
       setLogo(data.logo ?? null);
+      setSiteTitle(data.siteTitle);
+      setFavicon(data.favicon ?? null);
     }
   }, [data]);
 
-  const handleFile = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleLogoFile = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
-    setUploading(true);
+    setUploadingLogo(true);
     const reader = new FileReader();
     reader.onload = ev => {
       if (ev.target?.result) {
         setLogo(ev.target.result.toString());
       }
-      setUploading(false);
+      setUploadingLogo(false);
     };
-    reader.onerror = () => setUploading(false);
+    reader.onerror = () => setUploadingLogo(false);
     reader.readAsDataURL(file);
   };
 
-  const trigger = () => fileRef.current?.click();
+  const handleFaviconFile = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setUploadingFavicon(true);
+    const reader = new FileReader();
+    reader.onload = ev => {
+      if (ev.target?.result) {
+        setFavicon(ev.target.result.toString());
+      }
+      setUploadingFavicon(false);
+    };
+    reader.onerror = () => setUploadingFavicon(false);
+    reader.readAsDataURL(file);
+  };
+
+  const triggerLogo = () => logoFileRef.current?.click();
+  const triggerFavicon = () => faviconFileRef.current?.click();
 
   const save = () => {
-    update.mutate({ commissionRate: rate, logo });
+    update.mutate({
+      commissionRate: rate,
+      logo,
+      siteTitle,
+      favicon,
+    });
   };
 
   if (isLoading) {
@@ -73,9 +100,22 @@ export default function AdminSettingsPage() {
               <label className="block text-sm font-medium mb-1">Logo</label>
               {logo && <img src={logo} alt="Logo" className="h-16 mb-2" />}
               <Input value={logo || ""} onChange={e => setLogo(e.target.value)} placeholder="Image URL or data" />
-              <input type="file" ref={fileRef} className="hidden" accept="image/*" onChange={handleFile} />
-              <Button type="button" variant="outline" className="mt-2" onClick={trigger} disabled={uploading}>
-                {uploading ? (<><Loader2 className="mr-2 h-4 w-4 animate-spin"/>Uploading...</>) : (<><ImagePlus className="mr-2 h-4 w-4"/>Upload Image</>)}
+              <input type="file" ref={logoFileRef} className="hidden" accept="image/*" onChange={handleLogoFile} />
+              <Button type="button" variant="outline" className="mt-2" onClick={triggerLogo} disabled={uploadingLogo}>
+                {uploadingLogo ? (<><Loader2 className="mr-2 h-4 w-4 animate-spin"/>Uploading...</>) : (<><ImagePlus className="mr-2 h-4 w-4"/>Upload Image</>)}
+              </Button>
+            </div>
+            <div>
+              <label className="block text-sm font-medium mb-1">Site Title</label>
+              <Input value={siteTitle} onChange={e => setSiteTitle(e.target.value)} />
+            </div>
+            <div>
+              <label className="block text-sm font-medium mb-1">Favicon</label>
+              {favicon && <img src={favicon} alt="Favicon" className="h-8 w-8 mb-2" />}
+              <Input value={favicon || ""} onChange={e => setFavicon(e.target.value)} placeholder="Image URL or data" />
+              <input type="file" ref={faviconFileRef} className="hidden" accept="image/*" onChange={handleFaviconFile} />
+              <Button type="button" variant="outline" className="mt-2" onClick={triggerFavicon} disabled={uploadingFavicon}>
+                {uploadingFavicon ? (<><Loader2 className="mr-2 h-4 w-4 animate-spin"/>Uploading...</>) : (<><ImagePlus className="mr-2 h-4 w-4"/>Upload Image</>)}
               </Button>
             </div>
             <Button onClick={save} disabled={update.isPending}>

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1163,7 +1163,11 @@ export async function registerRoutes(app: Express): Promise<Server> {
     try {
       const rate = await getServiceFeeRate();
       const logo = await storage.getSiteSetting("logo");
-      res.json({ commissionRate: rate, logo });
+      const title =
+        (await storage.getSiteSetting("site_title")) ||
+        "SY Closeouts - B2B Wholesale Liquidation Marketplace";
+      const favicon = await storage.getSiteSetting("favicon");
+      res.json({ commissionRate: rate, logo, siteTitle: title, favicon });
     } catch (error) {
       handleApiError(res, error);
     }
@@ -1173,7 +1177,11 @@ export async function registerRoutes(app: Express): Promise<Server> {
     try {
       const rate = await getServiceFeeRate();
       const logo = await storage.getSiteSetting("logo");
-      res.json({ commissionRate: rate, logo });
+      const title =
+        (await storage.getSiteSetting("site_title")) ||
+        "SY Closeouts - B2B Wholesale Liquidation Marketplace";
+      const favicon = await storage.getSiteSetting("favicon");
+      res.json({ commissionRate: rate, logo, siteTitle: title, favicon });
     } catch (error) {
       handleApiError(res, error);
     }
@@ -1186,6 +1194,12 @@ export async function registerRoutes(app: Express): Promise<Server> {
       }
       if (req.body.logo !== undefined) {
         await storage.setSiteSetting("logo", req.body.logo ?? "");
+      }
+      if (req.body.siteTitle !== undefined) {
+        await storage.setSiteSetting("site_title", req.body.siteTitle ?? "");
+      }
+      if (req.body.favicon !== undefined) {
+        await storage.setSiteSetting("favicon", req.body.favicon ?? "");
       }
       res.sendStatus(204);
     } catch (error) {


### PR DESCRIPTION
## Summary
- extend site settings to include `siteTitle` and `favicon`
- allow admin to upload favicon and change site title
- expose new fields via settings API
- update headers/footers and SettingsLoader to use updated settings
- add favicon link element to `index.html`

## Testing
- `npm run check` *(fails: Cannot find module 'wouter' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6873e9c6db1c8330896227e16859c338