### PR TITLE
Fix offer timer logic and display

### DIFF
--- a/client/src/components/cart/cart-item.tsx
+++ b/client/src/components/cart/cart-item.tsx
@@ -6,6 +6,7 @@ import { formatCurrency } from "@/lib/utils";
 import { Minus, Plus, Trash2 } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { useCart } from "@/hooks/use-cart";
+import ExpirationTimer from "@/components/offers/expiration-timer";
 
 interface CartItemProps {
   item: CartItemType;
@@ -93,6 +94,9 @@ export default function CartItem({ item }: CartItemProps) {
           <p className="mt-1 text-sm text-gray-500">
             {item.quantity} units @ {formatCurrency(item.price)}/unit
           </p>
+          {isOfferItem && item.offerExpiresAt && (
+            <ExpirationTimer expiresAt={item.offerExpiresAt} />
+          )}
         </div>
         <div className="flex-1 flex items-end justify-between text-sm">
           <div className="flex items-center">

--- a/client/src/components/offers/expiration-timer.tsx
+++ b/client/src/components/offers/expiration-timer.tsx
@@ -1,0 +1,34 @@
+import { useState, useEffect } from "react";
+import { Clock } from "lucide-react";
+
+function parseDate(str: string) {
+  if (!str) return new Date(0);
+  return new Date(/Z$|[+-]\d{2}:\d{2}$/.test(str) ? str : str + "Z");
+}
+
+export default function ExpirationTimer({ expiresAt }: { expiresAt: string }) {
+  const [time, setTime] = useState("0m");
+
+  useEffect(() => {
+    function update() {
+      const diff = parseDate(expiresAt).getTime() - Date.now();
+      if (diff <= 0) {
+        setTime("0m");
+        return;
+      }
+      const h = Math.floor(diff / 1000 / 60 / 60);
+      const m = Math.floor((diff / 1000 / 60) % 60);
+      setTime(`${h}h ${m}m`);
+    }
+    update();
+    const id = setInterval(update, 60000);
+    return () => clearInterval(id);
+  }, [expiresAt]);
+
+  return (
+    <p className="text-red-600 text-sm flex items-center">
+      <Clock className="w-4 h-4 mr-1" />
+      {time} left
+    </p>
+  );
+}

--- a/client/src/hooks/use-cart.tsx
+++ b/client/src/hooks/use-cart.tsx
@@ -12,7 +12,8 @@ interface CartContextType {
     variations?: Record<string, string>,
     priceOverride?: number,
     offerQuantity?: number,
-    offerId?: number
+    offerId?: number,
+    offerExpiresAt?: string
   ) => void;
   removeFromCart: (productId: number, variationKey?: string, offerId?: number) => void;
   updateQuantity: (
@@ -106,7 +107,8 @@ export function CartProvider({ children }: { children: ReactNode }) {
     variations: Record<string, string> = {},
     priceOverride?: number,
     offerQuantity?: number,
-    offerId?: number
+    offerId?: number,
+    offerExpiresAt?: string
   ) => {
     if (quantity <= 0) return;
 
@@ -221,7 +223,8 @@ export function CartProvider({ children }: { children: ReactNode }) {
             selectedVariations: variations,
             variationKey: varKey,
             offerId,
-            offerQuantity
+            offerQuantity,
+            offerExpiresAt
           }
         ];
       }
@@ -248,7 +251,8 @@ export function CartProvider({ children }: { children: ReactNode }) {
         offer.selectedVariations ?? {},
         offer.price,
         offer.quantity,
-        offer.id
+        offer.id,
+        offer.expiresAt as string | undefined
       );
     } catch {
       /* ignore */

--- a/client/src/pages/buyer/offers.tsx
+++ b/client/src/pages/buyer/offers.tsx
@@ -7,38 +7,12 @@ import { getServiceFeeRate } from "@/hooks/use-settings";
 import { apiRequest, queryClient } from "@/lib/queryClient";
 import { useToast } from "@/hooks/use-toast";
 import { useCart } from "@/hooks/use-cart";
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import MakeOfferDialog from "@/components/products/make-offer-dialog";
-import { Clock } from "lucide-react";
+import ExpirationTimer from "@/components/offers/expiration-timer";
 
-function ExpirationTimer({ expiresAt }: { expiresAt: string }) {
-  const [time, setTime] = useState("0m");
-
-  useEffect(() => {
-    function update() {
-      const diff = new Date(expiresAt).getTime() - Date.now();
-      if (diff <= 0) {
-        setTime("0m");
-        return;
-      }
-      const h = Math.floor(diff / 1000 / 60 / 60);
-      const m = Math.floor((diff / 1000 / 60) % 60);
-      setTime(`${h}h ${m}m`);
-    }
-    update();
-    const id = setInterval(update, 60000);
-    return () => clearInterval(id);
-  }, [expiresAt]);
-
-  return (
-    <p className="text-red-600 text-sm flex items-center">
-      <Clock className="w-4 h-4 mr-1" />
-      {time} left
-    </p>
-  );
-}
 
 export default function BuyerOffersPage() {
   type OfferWithProduct = Offer & { productTitle: string; productImages: string[] };
@@ -94,7 +68,8 @@ export default function BuyerOffersPage() {
         o.selectedVariations ?? {},
         o.price,
         o.quantity,
-        o.id
+        o.id,
+        o.expiresAt as string | undefined
       );
     } catch (err) {
       console.error(err);

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -624,5 +624,7 @@ export interface CartItem {
   priceIncludesFee?: boolean;
   offerId?: number;
   offerQuantity?: number;
+  offerExpiresAt?: string;
   selectedVariations?: Record<string, string>;
-  variationKey?: string;}
+  variationKey?: string;
+}


### PR DESCRIPTION
## Summary
- show offer expiration countdown on cart items
- unify expiration timer component and use it on offers page
- pass offer expiration details when adding to cart
- extend cart item interface with offerExpiresAt

## Testing
- `npm run check` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_6873ea4a6fa08330ba744ef5eae76c42