### PR TITLE
Fix rounding for buyer offer display

### DIFF
--- a/client/src/pages/buyer/offers.tsx
+++ b/client/src/pages/buyer/offers.tsx
@@ -2,8 +2,7 @@ import { useQuery, useMutation } from "@tanstack/react-query";
 import { Offer } from "@shared/schema";
 import Header from "@/components/layout/header";
 import Footer from "@/components/layout/footer";
-import { formatCurrency, cn } from "@/lib/utils";
-import { getServiceFeeRate } from "@/hooks/use-settings";
+import { formatCurrency, cn, addServiceFee } from "@/lib/utils";
 import { apiRequest, queryClient } from "@/lib/queryClient";
 import { useToast } from "@/hooks/use-toast";
 import { useCart } from "@/hooks/use-cart";
@@ -153,7 +152,7 @@ export default function BuyerOffersPage() {
                             <p className="text-sm">Quantity: {o.quantity}</p>
                           </div>
                           <div className="text-right space-y-1">
-                            <p>{formatCurrency(o.price * (1 + getServiceFeeRate()))}</p>
+                            <p>{formatCurrency(addServiceFee(o.price))}</p>
                             <span className="text-xs capitalize">{o.status}</span>
                           </div>
                         </div>


### PR DESCRIPTION
## Summary
- show offer prices with commission using `addServiceFee`

## Testing
- `npm run check` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_6873ef0d5c388330aeab5748c99812f4