### PR TITLE
Fix rounding for offer prices

### DIFF
--- a/client/src/hooks/use-cart.tsx
+++ b/client/src/hooks/use-cart.tsx
@@ -13,7 +13,8 @@ interface CartContextType {
     priceOverride?: number,
     offerQuantity?: number,
     offerId?: number,
-    offerExpiresAt?: string
+    offerExpiresAt?: string,
+    priceIncludesFeeOverride?: boolean
   ) => void;
   removeFromCart: (productId: number, variationKey?: string, offerId?: number) => void;
   updateQuantity: (
@@ -54,13 +55,16 @@ export function CartProvider({ children }: { children: ReactNode }) {
           let includesFee = item.priceIncludesFee ?? false;
 
           const buyerLike = !user || user.role === "buyer" || user.role === "seller";
+          const hasOffer = item.offerId !== undefined;
 
-          if (!includesFee && buyerLike) {
-            price = addServiceFee(price);
-            includesFee = true;
-          } else if (includesFee && !buyerLike) {
-            price = removeServiceFee(price);
-            includesFee = false;
+          if (!hasOffer) {
+            if (!includesFee && buyerLike) {
+              price = addServiceFee(price);
+              includesFee = true;
+            } else if (includesFee && !buyerLike) {
+              price = removeServiceFee(price);
+              includesFee = false;
+            }
           }
 
           return {
@@ -108,7 +112,8 @@ export function CartProvider({ children }: { children: ReactNode }) {
     priceOverride?: number,
     offerQuantity?: number,
     offerId?: number,
-    offerExpiresAt?: string
+    offerExpiresAt?: string,
+    priceIncludesFeeOverride?: boolean
   ) => {
     if (quantity <= 0) return;
 
@@ -163,7 +168,7 @@ export function CartProvider({ children }: { children: ReactNode }) {
         : product.variationPrices && product.variationPrices[varKey] !== undefined
         ? product.variationPrices[varKey]
         : product.price;
-    const priceIncludesFee = !user || user.role === "buyer" || user.role === "seller";
+    const priceIncludesFee = priceIncludesFeeOverride ?? (!user || user.role === "buyer" || user.role === "seller");
     const priceWithFee = priceIncludesFee ? addServiceFee(basePrice) : basePrice;
 
       setItems(prevItems => {
@@ -252,7 +257,8 @@ export function CartProvider({ children }: { children: ReactNode }) {
         offer.price,
         offer.quantity,
         offer.id,
-        offer.expiresAt as string | undefined
+        offer.expiresAt as string | undefined,
+        false
       );
     } catch {
       /* ignore */

--- a/client/src/lib/utils.ts
+++ b/client/src/lib/utils.ts
@@ -25,6 +25,11 @@ export function addServiceFee(basePrice: number, rate: number = getServiceFeeRat
   return roundUpToCent(basePrice * (1 + rate));
 }
 
+// Subtract the service fee from a price and round to the nearest cent
+export function subtractServiceFee(amount: number, rate: number = getServiceFeeRate()): number {
+  return Math.round(amount * (1 - rate) * 100) / 100;
+}
+
 export function formatCurrency(amount: number): string {
   return new Intl.NumberFormat('en-US', {
     style: 'currency',
@@ -94,18 +99,18 @@ export function calculateOrderCommission(
   order: { items: { totalPrice: number }[] },
   rate: number = getServiceFeeRate(),
 ): number {
-  const productTotalWithFee = order.items.reduce((sum, i) => sum + i.totalPrice, 0);
-  const productTotalWithoutFee = removeServiceFee(productTotalWithFee, rate);
-  return Math.round((productTotalWithFee - productTotalWithoutFee) * 100) / 100;
+  const productTotal = order.items.reduce((sum, i) => sum + i.totalPrice, 0);
+  const payoutTotal = subtractServiceFee(productTotal, rate);
+  return Math.round((productTotal - payoutTotal) * 100) / 100;
 }
 
 export function calculateSellerPayout(
   order: { items: { totalPrice: number }[]; totalAmount: number },
   rate: number = getServiceFeeRate(),
 ): number {
-  const productTotalWithFee = order.items.reduce((sum, i) => sum + i.totalPrice, 0);
-  const shippingTotal = order.totalAmount - productTotalWithFee;
-  return Math.round((removeServiceFee(productTotalWithFee, rate) + shippingTotal) * 100) / 100;
+  const productTotal = order.items.reduce((sum, i) => sum + i.totalPrice, 0);
+  const shippingTotal = order.totalAmount - productTotal;
+  return Math.round((subtractServiceFee(productTotal, rate) + shippingTotal) * 100) / 100;
 }
 
 export function calculateShippingTotal(order: { items: { totalPrice: number }[]; totalAmount: number }): number {

--- a/client/src/pages/buyer/offers.tsx
+++ b/client/src/pages/buyer/offers.tsx
@@ -2,8 +2,7 @@ import { useQuery, useMutation } from "@tanstack/react-query";
 import { Offer } from "@shared/schema";
 import Header from "@/components/layout/header";
 import Footer from "@/components/layout/footer";
-import { formatCurrency, cn } from "@/lib/utils";
-import { getServiceFeeRate } from "@/hooks/use-settings";
+import { formatCurrency, cn, addServiceFee } from "@/lib/utils";
 import { apiRequest, queryClient } from "@/lib/queryClient";
 import { useToast } from "@/hooks/use-toast";
 import { useCart } from "@/hooks/use-cart";
@@ -153,7 +152,7 @@ export default function BuyerOffersPage() {
                             <p className="text-sm">Quantity: {o.quantity}</p>
                           </div>
                           <div className="text-right space-y-1">
-                            <p>{formatCurrency(o.price * (1 + getServiceFeeRate()))}</p>
+                            <p>{formatCurrency(addServiceFee(o.price))}</p>
                             <span className="text-xs capitalize">{o.status}</span>
                           </div>
                         </div>

--- a/client/src/pages/seller/order-detail.tsx
+++ b/client/src/pages/seller/order-detail.tsx
@@ -20,7 +20,7 @@ import OrderStatus from "@/components/buyer/order-status";
 import {
   formatCurrency,
   formatDate,
-  removeServiceFee,
+  subtractServiceFee,
   calculateSellerPayout,
   calculateShippingTotal,
 } from "@/lib/utils";
@@ -122,9 +122,9 @@ export default function SellerOrderDetailPage() {
                     </div>
                     <div className="text-right text-sm space-y-1">
                       <p>Qty: {item.quantity}</p>
-                      <p>{formatCurrency(removeServiceFee(item.unitPrice))} each</p>
+                      <p>{formatCurrency(subtractServiceFee(item.unitPrice))} each</p>
                       <p className="font-medium">
-                        {formatCurrency(removeServiceFee(item.totalPrice))}
+                        {formatCurrency(subtractServiceFee(item.totalPrice))}
                       </p>
                     </div>
                   </li>

--- a/server/email.ts
+++ b/server/email.ts
@@ -77,8 +77,8 @@ async function getServiceFeeRate(): Promise<number> {
   return Number.isFinite(num) ? num : 0.035;
 }
 
-function removeServiceFee(priceWithFee: number, rate: number): number {
-  return Math.floor((priceWithFee / (1 + rate)) * 100) / 100;
+function subtractServiceFee(amount: number, rate: number): number {
+  return Math.round(amount * (1 - rate) * 100) / 100;
 }
 
 export async function sendInvoiceEmail(
@@ -241,8 +241,8 @@ export async function sendSellerOrderEmail(
 
   const itemsNoFee = items.map((i) => ({
     ...i,
-    unitPrice: removeServiceFee(i.unitPrice, rate),
-    totalPrice: removeServiceFee(i.totalPrice, rate),
+    unitPrice: subtractServiceFee(i.unitPrice, rate),
+    totalPrice: subtractServiceFee(i.totalPrice, rate),
   }));
 
   const itemLines = itemsNoFee

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -57,6 +57,10 @@ function removeServiceFee(priceWithFee: number, rate: number): number {
   return Math.floor((priceWithFee / (1 + rate)) * 100) / 100;
 }
 
+function subtractServiceFee(amount: number, rate: number): number {
+  return Math.round(amount * (1 - rate) * 100) / 100;
+}
+
 async function fetchTrackingStatus(trackingNumber: string): Promise<string | undefined> {
   try {
     const apiKey = process.env.TRACKTRY_API_KEY;
@@ -456,8 +460,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
         const itemsNoFee = items.map((i) => ({
           title: i.productTitle,
           quantity: i.quantity,
-          unitPrice: removeServiceFee(i.unitPrice, rate),
-          totalPrice: removeServiceFee(i.totalPrice, rate),
+          unitPrice: subtractServiceFee(i.unitPrice, rate),
+          totalPrice: subtractServiceFee(i.totalPrice, rate),
           selectedVariations: i.selectedVariations,
         }));
         const subtotal = itemsNoFee.reduce((sum, it) => sum + it.totalPrice, 0);
@@ -1247,7 +1251,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
         // product total. Use the same rounding logic as when the fee was
         // applied so the amount matches what sellers expect.
         const payoutAmount =
-          Math.round((removeServiceFee(productTotalWithFee, rate) + shippingTotal) * 100) / 100;
+          Math.round((subtractServiceFee(productTotalWithFee, rate) + shippingTotal) * 100) / 100;
         groups[key].orders.push({ id: o.id, code: o.code, total_amount: payoutAmount });
         groups[key].total += payoutAmount;
       }
@@ -1292,7 +1296,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
         const shippingTotal = Number(p.total_amount) - productTotalWithFee;
         const rate = await getServiceFeeRate();
         const payoutAmount =
-          Math.round((removeServiceFee(productTotalWithFee, rate) + shippingTotal) * 100) /
+          Math.round((subtractServiceFee(productTotalWithFee, rate) + shippingTotal) * 100) /
           100;
         groups[p.seller_id].payouts.push({
           id: p.id,


### PR DESCRIPTION
## Summary
- preserve offer price on reload instead of reapplying service fees
- show seller payout using simple percentage instead of reversing fee

## Testing
- `npm run check` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_6873ef0d5c388330aeab5748c99812f4