### PR TITLE
Fix offer commission handling

### DIFF
--- a/client/src/hooks/use-cart.tsx
+++ b/client/src/hooks/use-cart.tsx
@@ -258,7 +258,7 @@ export function CartProvider({ children }: { children: ReactNode }) {
         offer.quantity,
         offer.id,
         offer.expiresAt as string | undefined,
-        false
+        true
       );
     } catch {
       /* ignore */


### PR DESCRIPTION
## Summary
- calculate seller amount by removing service fee when creating offers
- ensure buyer counter offers also store net price
- apply service fee when adding accepted offers to cart so buyers pay total amount

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687555b56f3c8330a1faa7e023268a6b