### PR TITLE
Fix offer pricing in cart

### DIFF
--- a/client/src/components/cart/cart-drawer.tsx
+++ b/client/src/components/cart/cart-drawer.tsx
@@ -84,7 +84,7 @@ export default function CartDrawer() {
                     <div className="flex-1">
                       <p className="text-sm font-medium">{o.productTitle}</p>
                       <p className="text-xs text-gray-500">
-                        Qty {o.quantity} · {formatCurrency(o.price)}
+                        Qty {o.quantity} · {formatCurrency(o.price + (o.serviceFee ?? 0))}
                       </p>
                     </div>
                     <Button size="sm" onClick={() => addOfferToCart(o)}>

--- a/client/src/hooks/use-cart.tsx
+++ b/client/src/hooks/use-cart.tsx
@@ -252,6 +252,7 @@ export function CartProvider({ children }: { children: ReactNode }) {
       const product: Product = await res.json();
       // Use the stored service fee so the buyer pays the exact offer amount
       // while the seller receives the net price without rounding errors.
+      // The provided price already includes the service fee so don't add it again.
       addToCart(
         product,
         offer.quantity,
@@ -260,7 +261,7 @@ export function CartProvider({ children }: { children: ReactNode }) {
         offer.quantity,
         offer.id,
         offer.expiresAt as string | undefined,
-        true
+        false
       );
     } catch {
       /* ignore */


### PR DESCRIPTION
## Summary
- fix cart offer price calculations to prevent double service fee
- display approved offer price including service fee

## Testing
- `npm run check` *(fails: cannot install dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687562432ecc8330aaf5c999480dbaef