### PR TITLE
Fix seller counter fee

### DIFF
--- a/client/src/hooks/use-cart.tsx
+++ b/client/src/hooks/use-cart.tsx
@@ -250,11 +250,13 @@ export function CartProvider({ children }: { children: ReactNode }) {
       const res = await fetch(`/api/products/${offer.productId}`);
       if (!res.ok) return;
       const product: Product = await res.json();
+      // Use the stored service fee so the buyer pays the exact offer amount
+      // while the seller receives the net price without rounding errors.
       addToCart(
         product,
         offer.quantity,
         offer.selectedVariations ?? {},
-        offer.price,
+        offer.price + (offer.serviceFee ?? 0),
         offer.quantity,
         offer.id,
         offer.expiresAt as string | undefined,

--- a/client/src/lib/utils.ts
+++ b/client/src/lib/utils.ts
@@ -25,6 +25,11 @@ export function addServiceFee(basePrice: number, rate: number = getServiceFeeRat
   return roundUpToCent(basePrice * (1 + rate));
 }
 
+// Calculate the service fee amount for a given price
+export function calculateServiceFee(amount: number, rate: number = getServiceFeeRate()): number {
+  return Math.round(amount * rate * 100) / 100;
+}
+
 // Subtract the service fee from a price and round to the nearest cent
 export function subtractServiceFee(amount: number, rate: number = getServiceFeeRate()): number {
   return Math.round(amount * (1 - rate) * 100) / 100;
@@ -100,7 +105,7 @@ export function calculateOrderCommission(
   rate: number = getServiceFeeRate(),
 ): number {
   const productTotal = order.items.reduce((sum, i) => sum + i.totalPrice, 0);
-  const payoutTotal = subtractServiceFee(productTotal, rate);
+  const payoutTotal = removeServiceFee(productTotal, rate);
   return Math.round((productTotal - payoutTotal) * 100) / 100;
 }
 
@@ -110,7 +115,7 @@ export function calculateSellerPayout(
 ): number {
   const productTotal = order.items.reduce((sum, i) => sum + i.totalPrice, 0);
   const shippingTotal = order.totalAmount - productTotal;
-  return Math.round((subtractServiceFee(productTotal, rate) + shippingTotal) * 100) / 100;
+  return Math.round((removeServiceFee(productTotal, rate) + shippingTotal) * 100) / 100;
 }
 
 export function calculateShippingTotal(order: { items: { totalPrice: number }[]; totalAmount: number }): number {

--- a/client/src/pages/buyer/offers.tsx
+++ b/client/src/pages/buyer/offers.tsx
@@ -152,7 +152,7 @@ export default function BuyerOffersPage() {
                             <p className="text-sm">Quantity: {o.quantity}</p>
                           </div>
                           <div className="text-right space-y-1">
-                            <p>{formatCurrency(addServiceFee(o.price))}</p>
+                            <p>{formatCurrency(o.price + (o.serviceFee ?? 0))}</p>
                             <span className="text-xs capitalize">{o.status}</span>
                           </div>
                         </div>

--- a/client/src/pages/seller/order-detail.tsx
+++ b/client/src/pages/seller/order-detail.tsx
@@ -20,7 +20,7 @@ import OrderStatus from "@/components/buyer/order-status";
 import {
   formatCurrency,
   formatDate,
-  subtractServiceFee,
+  removeServiceFee,
   calculateSellerPayout,
   calculateShippingTotal,
 } from "@/lib/utils";
@@ -122,9 +122,9 @@ export default function SellerOrderDetailPage() {
                     </div>
                     <div className="text-right text-sm space-y-1">
                       <p>Qty: {item.quantity}</p>
-                      <p>{formatCurrency(subtractServiceFee(item.unitPrice))} each</p>
+                      <p>{formatCurrency(removeServiceFee(item.unitPrice))} each</p>
                       <p className="font-medium">
-                        {formatCurrency(subtractServiceFee(item.totalPrice))}
+                        {formatCurrency(removeServiceFee(item.totalPrice))}
                       </p>
                     </div>
                   </li>

--- a/server/email.ts
+++ b/server/email.ts
@@ -81,6 +81,10 @@ function subtractServiceFee(amount: number, rate: number): number {
   return Math.round(amount * (1 - rate) * 100) / 100;
 }
 
+function removeServiceFee(priceWithFee: number, rate: number): number {
+  return Math.floor((priceWithFee / (1 + rate)) * 100) / 100;
+}
+
 export async function sendInvoiceEmail(
   to: string,
   order: Order,
@@ -241,8 +245,8 @@ export async function sendSellerOrderEmail(
 
   const itemsNoFee = items.map((i) => ({
     ...i,
-    unitPrice: subtractServiceFee(i.unitPrice, rate),
-    totalPrice: subtractServiceFee(i.totalPrice, rate),
+    unitPrice: removeServiceFee(i.unitPrice, rate),
+    totalPrice: removeServiceFee(i.totalPrice, rate),
   }));
 
   const itemLines = itemsNoFee

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -634,6 +634,7 @@ export class DatabaseStorage implements IStorage {
         buyerId: offers.buyerId,
         sellerId: offers.sellerId,
         price: offers.price,
+        serviceFee: offers.serviceFee,
         quantity: offers.quantity,
         selectedVariations: offers.selectedVariations,
         status: offers.status,

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -365,6 +365,7 @@ export const offers = pgTable("offers", {
   buyerId: integer("buyer_id").notNull(),
   sellerId: integer("seller_id").notNull(),
   price: doublePrecision("price").notNull(),
+  serviceFee: doublePrecision("service_fee").notNull(),
   quantity: integer("quantity").notNull(),
   selectedVariations: jsonb("selected_variations"),
   status: text("status").notNull().default("pending"), // pending, accepted, rejected, countered, expired


### PR DESCRIPTION
## Summary
- store service fee separately when sellers counter offers so buyers see the gross price
- keep offer-to-cart and offer listings using the service fee
- compute seller invoice values by reversing the fee calculation

## Testing
- `npm run check` *(fails: missing modules)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687555b56f3c8330a1faa7e023268a6b