### PR TITLE
Fix wire invoice email

### DIFF
--- a/server/email.ts
+++ b/server/email.ts
@@ -177,7 +177,7 @@ export async function sendInvoiceEmail(
                 <td colspan="2" align="right" style="padding-top:10px;"><strong>Subtotal:</strong></td>
                 <td align="right" style="padding-top:10px;">$${subtotal.toFixed(2)}</td>
               </tr>
-              ${shippingTotal > 0 ? `<tr><td colspan="2" align="right">Shipping:</td><td align="right">$${shippingTotal.toFixed(2)}</td></tr>` : ""}
+              ${shipping > 0 ? `<tr><td colspan="2" align="right">Shipping:</td><td align="right">$${shipping.toFixed(2)}</td></tr>` : ""}
               <tr>
                 <td colspan="2" align="right"><strong>Total:</strong></td>
                 <td align="right"><strong>$${order.totalAmount.toFixed(2)}</strong></td>


### PR DESCRIPTION
## Summary
- fix reference to shippingTotal when sending invoice email after wire payment

## Testing
- `npm run check` *(fails: cannot find some types)*

------
https://chatgpt.com/codex/tasks/task_e_68757e377a7c8330b249238276b56dc3