### PR TITLE
Simplify mobile menu and show orders on profile

### DIFF
--- a/client/src/components/layout/header.tsx
+++ b/client/src/components/layout/header.tsx
@@ -73,7 +73,6 @@ export default function Header({ dashboardTabs, onProfileClick }: HeaderProps) {
               </div>
               <nav className="hidden sm:ml-6 sm:flex sm:space-x-8 items-center">
                 {[
-                  !(user && user.role === "seller") && user?.role !== "admin" && { label: "Home", href: "/" },
                   { label: "Products", href: "/products" },
                   user?.role === "buyer" && {
                     label: "My Orders",
@@ -240,15 +239,38 @@ export default function Header({ dashboardTabs, onProfileClick }: HeaderProps) {
         {/* Mobile menu */}
         {isMenuOpen && (
           <div className="sm:hidden">
-            <div className="pt-2 pb-3 space-y-1">
-              <Link href="/">
-                <div
-                  className={`${isActive("/") ? "bg-primary border-primary text-white" : "border-transparent text-gray-600 hover:bg-gray-50 hover:border-gray-300 hover:text-gray-800"} block pl-3 pr-4 py-2 border-l-4 text-base font-medium`}
-                  onClick={() => setIsMenuOpen(false)}
-                >
-                  Home
+            {user ? (
+              <div className="pt-4 pb-3 border-b border-gray-200">
+                <div className="flex items-center px-4">
+                  <div className="flex-shrink-0">
+                    <Avatar className="h-10 w-10">
+                      <AvatarImage src={user.avatarUrl || undefined} alt={user.username} />
+                      <AvatarFallback>
+                        {user.firstName.charAt(0)}
+                        {user.lastName.charAt(0)}
+                      </AvatarFallback>
+                    </Avatar>
+                  </div>
+                  <div className="ml-3">
+                    <div className="text-base font-medium text-gray-800">
+                      {user.firstName} {user.lastName}
+                    </div>
+                    <div className="text-sm font-medium text-gray-500">{user.email}</div>
+                  </div>
                 </div>
-              </Link>
+              </div>
+            ) : (
+              <div className="pt-4 pb-3 border-b border-gray-200">
+                <div className="flex justify-center">
+                  <Link href="/auth">
+                    <Button className="w-full max-w-xs mx-4 bg-primary hover:bg-blue-700" onClick={() => setIsMenuOpen(false)}>
+                      Sign In
+                    </Button>
+                  </Link>
+                </div>
+              </div>
+            )}
+            <div className="pt-2 pb-3 space-y-1">
               <Link href="/products">
                 <div
                   className={`${isActive("/products") ? "bg-primary border-primary text-white" : "border-transparent text-gray-600 hover:bg-gray-50 hover:border-gray-300 hover:text-gray-800"} block pl-3 pr-4 py-2 border-l-4 text-base font-medium`}
@@ -285,66 +307,6 @@ export default function Header({ dashboardTabs, onProfileClick }: HeaderProps) {
               )}
             </div>
 
-            {user ? (
-              <div className="pt-4 pb-3 border-t border-gray-200">
-                <div className="flex items-center px-4">
-                  <div className="flex-shrink-0">
-                    <Avatar className="h-10 w-10">
-                      <AvatarImage src={user.avatarUrl || undefined} alt={user.username} />
-                      <AvatarFallback>
-                        {user.firstName.charAt(0)}
-                        {user.lastName.charAt(0)}
-                      </AvatarFallback>
-                    </Avatar>
-                  </div>
-                  <div className="ml-3">
-                    <div className="text-base font-medium text-gray-800">
-                      {user.firstName} {user.lastName}
-                    </div>
-                    <div className="text-sm font-medium text-gray-500">{user.email}</div>
-                  </div>
-                  <div className="ml-auto flex space-x-4">
-                    <Link href={user.role === "buyer" ? "/buyer/messages" : "/seller/messages"}>
-                      <Button variant="ghost" size="icon" className="text-gray-400 hover:text-gray-500 relative">
-                        <MessageCircle className="h-5 w-5" />
-                        {unread > 0 && (
-                          <Badge className="absolute -top-2 -right-2 bg-primary text-white text-xs h-5 w-5 flex items-center justify-center p-0">
-                            {unread}
-                          </Badge>
-                        )}
-                        <span className="sr-only">Messages</span>
-                      </Button>
-                    </Link>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      className="text-gray-400 hover:text-gray-500 relative"
-                      onClick={() => {
-                        setIsMenuOpen(false);
-                        setIsCartOpen(true);
-                      }}
-                    >
-                      <ShoppingCart className="h-5 w-5" />
-                      {itemCount > 0 && (
-                        <Badge className="absolute -top-2 -right-2 bg-red-500 text-white text-xs h-5 w-5 flex items-center justify-center p-0">
-                          {itemCount > 99 ? "99+" : itemCount}
-                        </Badge>
-                      )}
-                    </Button>
-                  </div>
-                </div>
-              </div>
-            ) : (
-              <div className="pt-4 pb-3 border-t border-gray-200">
-                <div className="flex justify-center">
-                  <Link href="/auth">
-                    <Button className="w-full max-w-xs mx-4 bg-primary hover:bg-blue-700" onClick={() => setIsMenuOpen(false)}>
-                      Sign In
-                    </Button>
-                  </Link>
-                </div>
-              </div>
-            )}
           </div>
         )}
       </header>

--- a/client/src/components/layout/mobile-nav.tsx
+++ b/client/src/components/layout/mobile-nav.tsx
@@ -49,19 +49,8 @@ export default function MobileNav() {
       )}
 
       <nav className="fixed bottom-0 inset-x-0 z-50 border-t bg-white shadow sm:hidden">
-      <ul className="flex justify-around">
-        {user?.role !== "seller" && (
-          <li className="flex-1">
-            <Link
-              href="/"
-              className={`flex flex-col items-center py-2 text-xs ${isActive("/") ? "text-primary" : "text-gray-500"}`}
-            >
-              <Home className="h-5 w-5" />
-              Home
-            </Link>
-          </li>
-        )}
-        <li className="flex-1">
+      <ul className="grid grid-cols-3 gap-y-2 p-2">
+        <li>
           <Link
             href="/products"
             className={`flex flex-col items-center py-2 text-xs ${isActive("/products") ? "text-primary" : "text-gray-500"}`}
@@ -71,7 +60,7 @@ export default function MobileNav() {
           </Link>
         </li>
         {user?.role === "buyer" && (
-          <li className="flex-1">
+          <li>
             <Link
               href="/buyer/orders"
               className={`flex flex-col items-center py-2 text-xs ${isActive("/buyer/orders") ? "text-primary" : "text-gray-500"}`}
@@ -82,7 +71,7 @@ export default function MobileNav() {
           </li>
         )}
         {user?.role === "buyer" && (
-          <li className="flex-1">
+          <li>
             <Link
               href="/buyer/offers"
               className={`flex flex-col items-center py-2 text-xs ${isActive("/buyer/offers") ? "text-primary" : "text-gray-500"}`}
@@ -93,7 +82,7 @@ export default function MobileNav() {
           </li>
         )}
         {user?.role === "seller" && (
-          <li className="flex-1">
+          <li>
             <Link
               href="/seller/orders"
               className={`flex flex-col items-center py-2 text-xs ${isActive("/seller/orders") ? "text-primary" : "text-gray-500"}`}
@@ -104,7 +93,7 @@ export default function MobileNav() {
           </li>
         )}
         {user?.role === "seller" && (
-          <li className="flex-1">
+          <li>
             <Link
               href="/seller/offers"
               className={`flex flex-col items-center py-2 text-xs ${isActive("/seller/offers") ? "text-primary" : "text-gray-500"}`}
@@ -115,7 +104,7 @@ export default function MobileNav() {
           </li>
         )}
         {user?.role === "seller" && (
-          <li className="flex-1">
+          <li>
             <Link
               href="/seller/payouts"
               className={`flex flex-col items-center py-2 text-xs ${isActive("/seller/payouts") ? "text-primary" : "text-gray-500"}`}
@@ -126,7 +115,7 @@ export default function MobileNav() {
           </li>
         )}
         {user && (
-          <li className="flex-1">
+          <li>
             <Link
               href={user.role === "buyer" ? "/buyer/messages" : "/seller/messages"}
               className={`flex flex-col items-center py-2 text-xs ${isActive(user.role === "buyer" ? "/buyer/messages" : "/seller/messages") ? "text-primary" : "text-gray-500"}`}
@@ -136,7 +125,7 @@ export default function MobileNav() {
             </Link>
           </li>
         )}
-        <li className="flex-1 relative">
+        <li className="relative">
           <button
             onClick={() => setIsCartOpen(true)}
             className="flex flex-col items-center py-2 text-xs text-gray-500 w-full"
@@ -150,7 +139,7 @@ export default function MobileNav() {
             </Badge>
           )}
         </li>
-        <li className="flex-1">
+        <li>
           {user ? (
             <SheetTrigger asChild>
               <button

--- a/client/src/pages/buyer/profile.tsx
+++ b/client/src/pages/buyer/profile.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { Address } from "@shared/schema";
+import { Address, Order } from "@shared/schema";
 import Header from "@/components/layout/header";
 import Footer from "@/components/layout/footer";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -9,13 +9,19 @@ import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { useAuth } from "@/hooks/use-auth";
 import { ChangePasswordDialog } from "@/components/account/change-password-dialog";
 import { EditProfileDialog } from "@/components/account/edit-profile-dialog";
-import { formatDate } from "@/lib/utils";
+import { formatDate, formatCurrency } from "@/lib/utils";
+import { Link } from "wouter";
 
 export default function BuyerProfilePage() {
   const { user } = useAuth();
 
   const { data: addresses = [] } = useQuery<Address[]>({
     queryKey: ["/api/addresses"],
+    enabled: !!user,
+  });
+
+  const { data: orders = [], isLoading: loadingOrders } = useQuery<Order[]>({
+    queryKey: ["/api/orders"],
     enabled: !!user,
   });
 
@@ -104,6 +110,45 @@ export default function BuyerProfilePage() {
                 </RadioGroup>
               )}
               <Button variant="outline" className="mt-4">Add New Address</Button>
+            </CardContent>
+          </Card>
+
+          <Card className="md:col-span-3">
+            <CardHeader className="p-4 sm:p-6">
+              <CardTitle>Recent Orders</CardTitle>
+            </CardHeader>
+            <CardContent className="p-4 sm:p-6">
+              {loadingOrders ? (
+                <div className="space-y-4">
+                  {[...Array(3)].map((_, i) => (
+                    <div key={i} className="h-16 bg-gray-100 rounded" />
+                  ))}
+                </div>
+              ) : orders.length === 0 ? (
+                <p className="text-sm text-gray-500">No orders yet</p>
+              ) : (
+                <div className="space-y-4">
+                  {orders.slice(0, 3).map((order) => (
+                    <div key={order.id} className="flex justify-between items-center border rounded-md p-4">
+                      <div>
+                        <h4 className="font-medium">Order #{order.code}</h4>
+                        <p className="text-sm text-gray-500">Placed on {formatDate(order.createdAt)}</p>
+                      </div>
+                      <div className="text-right">
+                        <p className="font-medium">{formatCurrency(order.totalAmount)}</p>
+                        <span className="text-xs px-2 py-1 rounded-full bg-gray-100">
+                          {order.status.replace("_", " ")}
+                        </span>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+              {orders.length > 0 && (
+                <Link href="/buyer/orders">
+                  <Button variant="outline" className="mt-4 w-full">View All Orders</Button>
+                </Link>
+              )}
             </CardContent>
           </Card>
 


### PR DESCRIPTION
## Summary
- clean up mobile dropdown layout
- preview recent orders on buyer profile page

## Testing
- `npm run check` *(fails: module errors)*

------
https://chatgpt.com/codex/tasks/task_e_6875848156008330b4663558c3aa3992