### PR TITLE
Hide order multiple badge for take all lots

### DIFF
--- a/client/src/components/products/product-card.tsx
+++ b/client/src/components/products/product-card.tsx
@@ -60,9 +60,11 @@ export default function ProductCard({ product }: ProductCardProps) {
               MOQ: {product.minOrderQuantity}
             </Badge>
           )}
-          <Badge variant="outline" className="bg-purple-100 text-purple-800 hover:bg-purple-100">
-            Order by {product.orderMultiple}
-          </Badge>
+          {product.minOrderQuantity < product.totalUnits && (
+            <Badge variant="outline" className="bg-purple-100 text-purple-800 hover:bg-purple-100">
+              Order by {product.orderMultiple}
+            </Badge>
+          )}
           <Badge
             variant="outline"
             className={product.availableUnits > 0 ? "bg-green-100 text-green-800 hover:bg-green-100" : "bg-red-100 text-red-800 hover:bg-red-100"}

--- a/client/src/components/products/product-list-item.tsx
+++ b/client/src/components/products/product-list-item.tsx
@@ -62,9 +62,11 @@ export default function ProductListItem({ product }: ProductListItemProps) {
                 MOQ: {product.minOrderQuantity}
               </Badge>
             )}
-            <Badge variant="outline" className="bg-purple-100 text-purple-800 hover:bg-purple-100">
-              Order by {product.orderMultiple}
-            </Badge>
+            {product.minOrderQuantity < product.totalUnits && (
+              <Badge variant="outline" className="bg-purple-100 text-purple-800 hover:bg-purple-100">
+                Order by {product.orderMultiple}
+              </Badge>
+            )}
             <Badge
               variant="outline"
               className={product.availableUnits > 0 ? "bg-green-100 text-green-800 hover:bg-green-100" : "bg-red-100 text-red-800 hover:bg-red-100"}


### PR DESCRIPTION
## Summary
- hide `Order by` badge when product is a Take All lot

## Testing
- `npm run check` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68758dd7a7308330a5c340899a43a4d6