### PR TITLE
Adjust list view badge layout

### DIFF
--- a/client/src/components/products/product-list-item.tsx
+++ b/client/src/components/products/product-list-item.tsx
@@ -28,6 +28,9 @@ export default function ProductListItem({ product }: ProductListItemProps) {
       ? addServiceFee(product.price)
       : product.price;
 
+  const isNew =
+    Date.now() - new Date(product.createdAt).getTime() < 7 * 24 * 60 * 60 * 1000;
+
   function handleAddToCart() {
     addToCart(product, product.minOrderQuantity, {});
   }
@@ -38,17 +41,22 @@ export default function ProductListItem({ product }: ProductListItemProps) {
         href={`/products/${product.id}`}
         className="relative w-32 shrink-0 border-r flex items-center justify-center bg-background"
       >
+        {isNew && (
+          <Badge className="absolute top-2 left-2 z-10 bg-blue-500 text-white">
+            New
+          </Badge>
+        )}
         <img
           src={product.images[0]}
           alt={product.title}
           className="absolute inset-0 w-full h-full object-contain p-4"
         />
       </Link>
-      <CardContent className="flex flex-col sm:flex-row flex-1 justify-between gap-4">
+      <CardContent className="flex flex-col sm:flex-row flex-1 justify-between gap-4 p-4">
         <div className="flex flex-col gap-1">
           <Link
             href={`/products/${product.id}`}
-            className="text-sm font-medium text-primary hover:underline line-clamp-2"
+            className="mt-1 text-sm font-medium text-primary hover:underline line-clamp-2"
           >
             {product.title}
           </Link>
@@ -78,7 +86,7 @@ export default function ProductListItem({ product }: ProductListItemProps) {
             </Badge>
           </div>
         </div>
-        <div className="flex flex-col items-start sm:items-end gap-2 shrink-0">
+        <div className="flex flex-col items-start sm:items-end gap-3 shrink-0 mt-2 sm:mt-0">
           <p className="text-base font-semibold text-gray-900">
             {formatCurrency(displayPrice)}{' '}
             <span className="text-xs font-normal text-gray-600">/unit</span>


### PR DESCRIPTION
## Summary
- show a `New` badge overlay on list items when the product was created in the last week
- pad list item card content and add spacing for better layout
- offset price actions and shift title down

## Testing
- `npm run check` *(fails: Cannot find modules while installing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68758f1de5f88330bc16a9f3b48a7b25