### PR TITLE
Improve mobile chat layout

### DIFF
--- a/client/src/components/messages/chat-message.tsx
+++ b/client/src/components/messages/chat-message.tsx
@@ -13,7 +13,7 @@ export default function ChatMessage({ message, isOwn }: ChatMessageProps) {
         className={`max-w-[70%] rounded-2xl px-4 py-2 text-sm whitespace-pre-wrap break-words ${
           isOwn
             ? "bg-primary text-primary-foreground"
-            : "bg-muted"
+            : "bg-card border"
         }`}
       >
         {message.content}

--- a/client/src/pages/conversation.tsx
+++ b/client/src/pages/conversation.tsx
@@ -68,13 +68,13 @@ export default function ConversationPage() {
   return (
     <>
       <Header />
-      <main className="max-w-7xl mx-auto px-4 py-4 flex h-[calc(100vh-8rem)] gap-4">
-        <div className="hidden md:block w-64 border-r overflow-y-auto bg-white shadow-sm rounded-lg">
+      <main className="max-w-7xl mx-auto px-4 py-4 flex flex-col md:flex-row h-[calc(100dvh-8rem)] gap-4 overflow-hidden">
+        <div className="md:w-64 h-48 md:h-auto overflow-y-auto bg-white shadow-sm rounded-lg border md:border-r mb-4 md:mb-0">
           {others.map(id => (
             <ConversationPreview key={id} otherId={id} selected={id === otherId} />
           ))}
         </div>
-        <div className="flex-1 flex flex-col gap-2">
+        <div className="flex-1 flex flex-col gap-2 overflow-hidden">
           {listing && (
             <ListingBanner
               productId={listing.productId}


### PR DESCRIPTION
## Summary
- show conversation list on small screens and make layout responsive
- use a white bubble with a border for incoming messages so they stand out

## Testing
- `npm run check` *(fails: missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_68759213913083308d8450210b7268c5