### PR TITLE
Improve mobile chat layout

### DIFF
--- a/client/src/components/messages/chat-message.tsx
+++ b/client/src/components/messages/chat-message.tsx
@@ -13,7 +13,7 @@ export default function ChatMessage({ message, isOwn }: ChatMessageProps) {
         className={`max-w-[70%] rounded-2xl px-4 py-2 text-sm whitespace-pre-wrap break-words ${
           isOwn
             ? "bg-primary text-primary-foreground"
-            : "bg-muted"
+            : "bg-card border"
         }`}
       >
         {message.content}


### PR DESCRIPTION
## Summary
- show conversation list on small screens and make layout responsive
- use a white bubble with a border for incoming messages so they stand out
- show a back button instead of the conversation list
- stop automatically scrolling to the bottom when opening a conversation

## Testing
- `npm run check` *(fails: cannot find module wouter etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68759213913083308d8450210b7268c5