### PR TITLE
Improve seller mobile nav and layout

### DIFF
--- a/client/src/components/layout/mobile-nav.tsx
+++ b/client/src/components/layout/mobile-nav.tsx
@@ -1,5 +1,12 @@
 import { Link, useLocation } from "wouter";
-import { ShoppingBag, ShoppingCart, ListOrdered, MessageCircle, DollarSign, CalendarIcon } from "lucide-react";
+import {
+  ShoppingBag,
+  ShoppingCart,
+  ListOrdered,
+  MessageCircle,
+  DollarSign,
+  LayoutDashboard,
+} from "lucide-react";
 import { useCart } from "@/hooks/use-cart";
 import { useAuth } from "@/hooks/use-auth";
 import { Badge } from "@/components/ui/badge";
@@ -23,6 +30,17 @@ export default function MobileNav() {
             Shop
           </Link>
         </li>
+        {user?.role === "seller" && (
+          <li>
+            <Link
+              href="/seller/dashboard"
+              className={`flex flex-col items-center py-2 text-xs ${isActive("/seller/dashboard") ? "text-primary" : "text-gray-500"}`}
+            >
+              <LayoutDashboard className="h-5 w-5" />
+              Dashboard
+            </Link>
+          </li>
+        )}
         {user?.role === "buyer" && (
           <li>
             <Link
@@ -64,17 +82,6 @@ export default function MobileNav() {
             >
               <DollarSign className="h-5 w-5" />
               Offers
-            </Link>
-          </li>
-        )}
-        {user?.role === "seller" && (
-          <li>
-            <Link
-              href="/seller/payouts"
-              className={`flex flex-col items-center py-2 text-xs ${isActive("/seller/payouts") ? "text-primary" : "text-gray-500"}`}
-            >
-              <CalendarIcon className="h-5 w-5" />
-              Payouts
             </Link>
           </li>
         )}

--- a/client/src/pages/seller/dashboard.tsx
+++ b/client/src/pages/seller/dashboard.tsx
@@ -39,11 +39,10 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
 import { 
   BarChart4,
-  CalendarIcon, 
+  CalendarIcon,
   Package,
   PackagePlus,
   PlusCircle,
-  DollarSign,
   PieChart,
   TrendingUp,
   Loader2,
@@ -357,23 +356,11 @@ export default function SellerDashboard() {
               Welcome back, {user?.firstName}
             </p>
           </div>
-          <div className="grid grid-cols-2 sm:flex sm:space-x-4 gap-2">
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
             <Link href="/seller/products">
               <Button variant="outline" className="flex items-center">
                 <Package className="mr-2 h-4 w-4" />
                 My Products
-              </Button>
-            </Link>
-            <Link href="/seller/orders">
-              <Button variant="outline" className="flex items-center">
-                <ListOrdered className="mr-2 h-4 w-4" />
-                Orders
-              </Button>
-            </Link>
-            <Link href="/seller/offers">
-              <Button variant="outline" className="flex items-center">
-                <DollarSign className="mr-2 h-4 w-4" />
-                Offers
               </Button>
             </Link>
             <Link href="/seller/analytics">

--- a/client/src/pages/seller/offers.tsx
+++ b/client/src/pages/seller/offers.tsx
@@ -100,7 +100,7 @@ export default function SellerOffersPage() {
             <p>Loading...</p>
           ) : (
             <>
-              <div className="flex space-x-2 mb-4">
+              <div className="flex flex-wrap gap-2 mb-4">
                 {([
                   { label: "Pending", key: "pending", color: "bg-yellow-600" },
                   { label: "Countered", key: "countered", color: "bg-blue-600" },


### PR DESCRIPTION
## Summary
- add seller dashboard button to mobile navigation
- remove payouts from mobile navigation
- clean up top action buttons on seller dashboard
- wrap offers status buttons on small screens

## Testing
- `npm run check` *(fails: cannot find module)*

------
https://chatgpt.com/codex/tasks/task_e_6875b308644083308aec6dfe001ca839