### PR TITLE
Include offer details in email notifications

### DIFF
--- a/server/email.ts
+++ b/server/email.ts
@@ -1009,14 +1009,35 @@ export async function sendOfferEmail(
   message: string,
   buttonUrl: string,
   buttonText: string,
+  details?: { productTitle: string; price: number; quantity: number },
 ) {
   if (!transporter) {
     console.warn("Email transport not configured; skipping offer email");
     return;
   }
 
+  const detailHtml = details
+    ? `<table style="width:100%;border-collapse:collapse;margin:10px 0;">
+        <tr style="background:#f0f0f0;">
+          <th align="left" style="padding:4px 8px;">Product</th>
+          <th align="center" style="padding:4px 8px;">Qty</th>
+          <th align="right" style="padding:4px 8px;">Price</th>
+        </tr>
+        <tr>
+          <td style="padding:4px 8px;">${details.productTitle}</td>
+          <td align="center" style="padding:4px 8px;">${details.quantity}</td>
+          <td align="right" style="padding:4px 8px;">$${details.price.toFixed(2)}</td>
+        </tr>
+      </table>`
+    : "";
+
+  const textDetails = details
+    ? `\nProduct: ${details.productTitle}\nQuantity: ${details.quantity}\nPrice: $${details.price.toFixed(2)}`
+    : "";
+
   const htmlBody = `
     <p style="margin-top:0;">${message}</p>
+    ${detailHtml}
     <p style="text-align:center;margin:20px 0;">
       <a href="${buttonUrl}" style="background-color:#3498db;color:#ffffff;text-decoration:none;padding:12px 24px;border-radius:4px;display:inline-block;">${buttonText}</a>
     </p>
@@ -1027,7 +1048,7 @@ export async function sendOfferEmail(
     from: process.env.SMTP_FROM || user,
     to,
     subject,
-    text: `${message}\n${buttonUrl}`,
+    text: `${message}${textDetails}\n${buttonUrl}`,
     html: wrapTemplate(subject, htmlBody),
     attachments: [logo],
   } as nodemailer.SendMailOptions;
@@ -1039,32 +1060,99 @@ export async function sendOfferEmail(
   }
 }
 
-export async function sendNewOfferEmail(to: string, productTitle: string) {
+export async function sendNewOfferEmail(
+  to: string,
+  productTitle: string,
+  price: number,
+  quantity: number,
+) {
   await sendOfferEmail(
     to,
     `New offer for ${productTitle}`,
     `You have received a new offer for ${productTitle}.`,
     `https://sycloseouts.com/seller/offers`,
     "View Offer",
+    { productTitle, price, quantity },
   );
 }
 
-export async function sendOfferAcceptedEmail(to: string, productTitle: string) {
+export async function sendOfferAcceptedEmail(
+  to: string,
+  productTitle: string,
+  price: number,
+  quantity: number,
+) {
   await sendOfferEmail(
     to,
     `Offer for ${productTitle} accepted`,
     `Your offer for ${productTitle} was accepted. You can add the item to your cart.`,
     `https://sycloseouts.com/buyer/offers`,
     "Add to Cart",
+    { productTitle, price, quantity },
   );
 }
 
-export async function sendOfferRejectedEmail(to: string, productTitle: string) {
+export async function sendOfferRejectedEmail(
+  to: string,
+  productTitle: string,
+  price: number,
+  quantity: number,
+) {
   await sendOfferEmail(
     to,
     `Offer for ${productTitle} rejected`,
     `Your offer for ${productTitle} was rejected.`,
     `https://sycloseouts.com/buyer/offers`,
     "View Offer",
+    { productTitle, price, quantity },
+  );
+}
+
+export async function sendCounterOfferEmail(
+  to: string,
+  productTitle: string,
+  price: number,
+  quantity: number,
+  forBuyer: boolean,
+) {
+  await sendOfferEmail(
+    to,
+    `Counter offer for ${productTitle}`,
+    `You have received a counter offer for ${productTitle}.`,
+    forBuyer ? `https://sycloseouts.com/buyer/offers` : `https://sycloseouts.com/seller/offers`,
+    "View Offer",
+    { productTitle, price, quantity },
+  );
+}
+
+export async function sendCounterAcceptedEmail(
+  to: string,
+  productTitle: string,
+  price: number,
+  quantity: number,
+) {
+  await sendOfferEmail(
+    to,
+    `Counter offer for ${productTitle} accepted`,
+    `Your counter offer for ${productTitle} was accepted.`,
+    `https://sycloseouts.com/seller/offers`,
+    "View Offer",
+    { productTitle, price, quantity },
+  );
+}
+
+export async function sendCounterRejectedEmail(
+  to: string,
+  productTitle: string,
+  price: number,
+  quantity: number,
+) {
+  await sendOfferEmail(
+    to,
+    `Counter offer for ${productTitle} rejected`,
+    `Your counter offer for ${productTitle} was rejected.`,
+    `https://sycloseouts.com/seller/offers`,
+    "View Offer",
+    { productTitle, price, quantity },
   );
 }

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -18,6 +18,12 @@ import {
   sendSupportTicketEmail,
   sendStrikeEmail,
   sendOrderCancelledEmail,
+  sendNewOfferEmail,
+  sendOfferAcceptedEmail,
+  sendOfferRejectedEmail,
+  sendCounterOfferEmail,
+  sendCounterAcceptedEmail,
+  sendCounterRejectedEmail,
 } from "./email";
 import { generateInvoicePdf, generateSalesReportPdf } from "./pdf";
 import { addSubscription, sendPushNotification } from "./push";
@@ -263,6 +269,16 @@ export async function registerRoutes(app: Express): Promise<Server> {
         content: `New offer for ${product.title}`,
         link: `/seller/offers`,
       });
+
+      const seller = await storage.getUser(product.sellerId);
+      if (seller) {
+        sendNewOfferEmail(
+          seller.email,
+          product.title,
+          req.body.price,
+          req.body.quantity,
+        ).catch(console.error);
+      }
 
       res.status(201).json(offer);
     } catch (error) {
@@ -1738,6 +1754,18 @@ export async function registerRoutes(app: Express): Promise<Server> {
         link: `/buyer/offers`,
       });
 
+      const buyer = await storage.getUser(offer.buyerId);
+      const product = await storage.getProduct(offer.productId);
+      if (buyer && product) {
+        const priceOffered = offer.price + offer.serviceFee;
+        sendOfferAcceptedEmail(
+          buyer.email,
+          product.title,
+          priceOffered,
+          offer.quantity,
+        ).catch(console.error);
+      }
+
       res.json(updated);
     } catch (error) {
       handleApiError(res, error);
@@ -1793,6 +1821,18 @@ export async function registerRoutes(app: Express): Promise<Server> {
         link: `/buyer/offers`,
       });
 
+      const buyer = await storage.getUser(offer.buyerId);
+      if (buyer) {
+        const priceWithFee = updated.price + updated.serviceFee;
+        sendCounterOfferEmail(
+          buyer.email,
+          product.title,
+          priceWithFee,
+          updated.quantity,
+          true,
+        ).catch(console.error);
+      }
+
       res.json(updated);
     } catch (error) {
       handleApiError(res, error);
@@ -1829,6 +1869,18 @@ export async function registerRoutes(app: Express): Promise<Server> {
         link: `/seller/offers`,
       });
 
+      const seller = await storage.getUser(offer.sellerId);
+      const product = await storage.getProduct(offer.productId);
+      if (seller && product) {
+        const priceOffered = offer.price + offer.serviceFee;
+        sendCounterAcceptedEmail(
+          seller.email,
+          product.title,
+          priceOffered,
+          offer.quantity,
+        ).catch(console.error);
+      }
+
       res.json(updated);
     } catch (error) {
       handleApiError(res, error);
@@ -1861,6 +1913,18 @@ export async function registerRoutes(app: Express): Promise<Server> {
         content: `Counter offer rejected by buyer`,
         link: `/seller/offers`,
       });
+
+      const seller = await storage.getUser(offer.sellerId);
+      const product = await storage.getProduct(offer.productId);
+      if (seller && product) {
+        const priceOffered = offer.price + offer.serviceFee;
+        sendCounterRejectedEmail(
+          seller.email,
+          product.title,
+          priceOffered,
+          offer.quantity,
+        ).catch(console.error);
+      }
 
       res.sendStatus(204);
     } catch (error) {
@@ -1914,6 +1978,18 @@ export async function registerRoutes(app: Express): Promise<Server> {
         link: `/seller/offers`,
       });
 
+      const seller = await storage.getUser(offer.sellerId);
+      if (seller) {
+        const priceOffered = price; // buyer offered price includes fee
+        sendCounterOfferEmail(
+          seller.email,
+          product.title,
+          priceOffered,
+          quantity,
+          false,
+        ).catch(console.error);
+      }
+
       res.json(updated);
     } catch (error) {
       handleApiError(res, error);
@@ -1946,6 +2022,18 @@ export async function registerRoutes(app: Express): Promise<Server> {
         content: `Your offer for ${offer.quantity} units was rejected`,
         link: `/buyer/home`,
       });
+
+      const buyer = await storage.getUser(offer.buyerId);
+      const product = await storage.getProduct(offer.productId);
+      if (buyer && product) {
+        const priceOffered = offer.price + offer.serviceFee;
+        sendOfferRejectedEmail(
+          buyer.email,
+          product.title,
+          priceOffered,
+          offer.quantity,
+        ).catch(console.error);
+      }
 
       res.sendStatus(204);
     } catch (error) {


### PR DESCRIPTION
## Summary
- display product, price and quantity in offer-related emails
- update server routes to pass offer details to email helpers

## Testing
- `npm run check` *(fails: missing type declarations and modules)*

------
https://chatgpt.com/codex/tasks/task_e_6875b6c6a160833089fe3ee6043652bb