### PR TITLE
Fix seller dashboard chart

### DIFF
--- a/client/src/pages/seller/analytics.tsx
+++ b/client/src/pages/seller/analytics.tsx
@@ -10,6 +10,7 @@ import { formatCurrency, formatDate } from "@/lib/utils";
 
 interface SummaryRow {
   date: string;
+  orders: number;
   revenue: number;
 }
 
@@ -29,9 +30,13 @@ export default function SellerAnalyticsPage() {
   const { user } = useAuth();
   const [range, setRange] = useState(30);
 
-  const start = new Date(Date.now() - range * 86400000);
-  const startStr = start.toISOString().slice(0, 10);
-  const endStr = new Date().toISOString().slice(0, 10);
+  const endDate = new Date();
+  endDate.setHours(23, 59, 59, 999);
+  const startDate = new Date(endDate);
+  startDate.setDate(endDate.getDate() - range + 1);
+  startDate.setHours(0, 0, 0, 0);
+  const startStr = startDate.toISOString().slice(0, 10);
+  const endStr = endDate.toISOString().slice(0, 10);
 
   const { data: rows = [] } = useQuery<SummaryRow[]>({
     queryKey: [`/api/seller/sales?start=${startStr}&end=${endStr}`],
@@ -107,6 +112,7 @@ export default function SellerAnalyticsPage() {
               <thead>
                 <tr className="border-b">
                   <th className="py-2 px-4 text-left">Date</th>
+                  <th className="py-2 px-4 text-right">Orders</th>
                   <th className="py-2 px-4 text-right">Revenue</th>
                 </tr>
               </thead>
@@ -114,6 +120,7 @@ export default function SellerAnalyticsPage() {
                 {rows.map((row) => (
                   <tr key={row.date} className="border-b hover:bg-gray-50">
                     <td className="py-2 px-4">{formatDate(row.date)}</td>
+                    <td className="py-2 px-4 text-right">{row.orders}</td>
                     <td className="py-2 px-4 text-right">{formatCurrency(row.revenue)}</td>
                   </tr>
                 ))}

--- a/client/src/pages/seller/dashboard.tsx
+++ b/client/src/pages/seller/dashboard.tsx
@@ -57,6 +57,7 @@ import {
   Tooltip as RechartsTooltip,
   ResponsiveContainer,
   Cell,
+  Legend,
 } from "recharts";
 import { useAuth } from "@/hooks/use-auth";
 import { formatCurrency, formatDate, calculateSellerPayout } from "@/lib/utils";
@@ -315,29 +316,33 @@ export default function SellerDashboard() {
   );
 
   const today = new Date();
+  today.setHours(0, 0, 0, 0);
   const weekStart = new Date(today);
   weekStart.setDate(today.getDate() - 6);
+  const weekEnd = new Date(today);
+  weekEnd.setHours(23, 59, 59, 999);
   const startStr = weekStart.toISOString().slice(0, 10);
-  const endStr = today.toISOString().slice(0, 10);
+  const endStr = weekEnd.toISOString().slice(0, 10);
 
-  const { data: weeklySales = [] } = useQuery<{ date: string; revenue: number }[]>({
+  const { data: weeklySales = [] } = useQuery<{ date: string; orders: number; revenue: number }[]>({
     queryKey: [`/api/seller/sales?start=${startStr}&end=${endStr}`],
     enabled: !!user,
   });
 
   const weeklySalesData = useMemo(() => {
-    const map: Record<string, number> = {};
+    const map: Record<string, { orders: number; revenue: number }> = {};
     for (const row of weeklySales) {
-      map[row.date] = row.revenue;
+      map[row.date] = { orders: row.orders, revenue: row.revenue };
     }
-    const arr: { label: string; revenue: number; isToday: boolean }[] = [];
+    const arr: { label: string; orders: number; revenue: number; isToday: boolean }[] = [];
     for (let i = 6; i >= 0; i--) {
       const d = new Date(today);
       d.setDate(today.getDate() - i);
       const key = d.toISOString().slice(0, 10);
       arr.push({
         label: d.toLocaleDateString('en-US', { month: 'short', day: 'numeric' }),
-        revenue: map[key] ?? 0,
+        revenue: map[key]?.revenue ?? 0,
+        orders: map[key]?.orders ?? 0,
         isToday: i === 0,
       });
     }
@@ -493,13 +498,23 @@ export default function SellerDashboard() {
                     <BarChart data={weeklySalesData} margin={{ top: 10, right: 10, left: 0, bottom: 0 }}>
                       <CartesianGrid strokeDasharray="3 3" />
                       <XAxis dataKey="label" />
-                      <YAxis tickFormatter={(v) => `$${v}`} />
-                      <RechartsTooltip formatter={(v) => formatCurrency(Number(v))} />
-                      <Bar dataKey="revenue">
+                      <YAxis yAxisId="revenue" tickFormatter={(v) => `$${v}`} />
+                      <YAxis yAxisId="orders" orientation="right" />
+                      <RechartsTooltip
+                        formatter={(v, name) =>
+                          name === "revenue" ? formatCurrency(Number(v)) : String(v)
+                        }
+                      />
+                      <Legend />
+                      <Bar yAxisId="revenue" dataKey="revenue" name="Revenue">
                         {weeklySalesData.map((entry, index) => (
-                          <Cell key={`cell-${index}`} fill={entry.isToday ? 'hsl(var(--primary))' : 'hsl(var(--muted-foreground))'} />
+                          <Cell
+                            key={`cell-rev-${index}`}
+                            fill={entry.isToday ? "hsl(var(--primary))" : "hsl(var(--muted-foreground))"}
+                          />
                         ))}
                       </Bar>
+                      <Bar yAxisId="orders" dataKey="orders" fill="hsl(var(--secondary))" name="Orders" />
                     </BarChart>
                   </ResponsiveContainer>
                 </div>

--- a/server/pdf.ts
+++ b/server/pdf.ts
@@ -125,6 +125,7 @@ export function generateInvoicePdf(order: Order, items: InvoiceItem[]): Buffer {
 
 export interface SalesSummary {
   date: string;
+  orders: number;
   revenue: number;
 }
 

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1664,6 +1664,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
       }
       const start = req.query.start ? new Date(String(req.query.start)) : new Date(Date.now() - 30 * 86400000);
       const end = req.query.end ? new Date(String(req.query.end)) : new Date();
+      start.setHours(0, 0, 0, 0);
+      end.setHours(23, 59, 59, 999);
       const sellerId = user.role === "seller" ? user.id : user.id;
       const summary = await storage.getSalesSummary(sellerId, start, end);
       res.json(summary);

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -760,16 +760,20 @@ export class DatabaseStorage implements IStorage {
     sellerId: number,
     start: Date,
     end: Date,
-  ): Promise<{ date: string; revenue: number }[]> {
+  ): Promise<{ date: string; orders: number; revenue: number }[]> {
     const result = await pool.query(
-      `SELECT DATE(created_at) AS date, SUM(total_amount) AS revenue
+      `SELECT DATE(created_at) AS date, COUNT(*) AS orders, SUM(total_amount) AS revenue
          FROM orders
         WHERE seller_id = $1 AND created_at BETWEEN $2 AND $3
         GROUP BY DATE(created_at)
         ORDER BY DATE(created_at)`,
       [sellerId, start, end],
     );
-    return result.rows.map((r) => ({ date: r.date, revenue: Number(r.revenue) }));
+    return result.rows.map((r) => ({
+      date: r.date,
+      orders: Number(r.orders),
+      revenue: Number(r.revenue),
+    }));
   }
 
   async getOrdersForBilling(): Promise<any[]> {


### PR DESCRIPTION
## Summary
- include order counts in sales summary
- display orders and revenue in seller analytics
- add dual-axis bar chart for orders and revenue
- ensure date ranges include full days

## Testing
- `npm run check` *(fails: Cannot find modules and other TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_6875b83995ac8330af2e63885f640312