### PR TITLE
Fix counter offer flow and seller dashboard

### DIFF
--- a/client/src/pages/seller/dashboard.tsx
+++ b/client/src/pages/seller/dashboard.tsx
@@ -107,7 +107,9 @@ export default function SellerDashboard() {
     enabled: !!user,
   });
 
-  const pendingOffers = offers.filter((o) => o.status === "pending");
+  const actionOffers = offers.filter(
+    (o) => o.status === "pending" || o.status === "countered",
+  );
 
   const recentOffersCard = (
     <Card>
@@ -116,11 +118,11 @@ export default function SellerDashboard() {
         <CardDescription>Offers from buyers</CardDescription>
       </CardHeader>
       <CardContent>
-        {pendingOffers.length === 0 ? (
+        {actionOffers.length === 0 ? (
           <p className="text-sm text-gray-500">No offers yet.</p>
         ) : (
           <div className="space-y-4">
-            {pendingOffers.slice(0, 5).map((o) => (
+            {actionOffers.slice(0, 5).map((o) => (
               <div key={o.id} className="border rounded-lg p-4 flex gap-4 justify-between">
                 {o.productImages?.[0] && (
                   <img
@@ -402,7 +404,7 @@ export default function SellerDashboard() {
               Welcome back, {user?.firstName}
             </p>
           </div>
-          <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+          <div className="grid grid-cols-2 sm:grid-cols-5 gap-2">
             <Link href="/seller/products" className="w-full">
               <Button variant="outline" className="flex items-center w-full justify-center text-xs sm:text-sm">
                 <Package className="mr-2 h-4 w-4" />
@@ -421,6 +423,12 @@ export default function SellerDashboard() {
                 Payouts
               </Button>
             </Link>
+            <Link href="/seller/offers" className="w-full">
+              <Button variant="outline" className="flex items-center w-full justify-center text-xs sm:text-sm">
+                <TrendingUp className="mr-2 h-4 w-4" />
+                Offers
+              </Button>
+            </Link>
             <Link href="/seller/products?action=new" className="w-full">
               <Button className="flex items-center w-full justify-center text-xs sm:text-sm">
                 <PlusCircle className="mr-2 h-4 w-4" />
@@ -431,7 +439,7 @@ export default function SellerDashboard() {
         </div>
         
         <TabsContent value="overview" className="space-y-6">
-            {pendingOffers.length > 0 && recentOffersCard}
+            {actionOffers.length > 0 && recentOffersCard}
             {/* Stats Cards */}
             <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
               <Card>
@@ -802,7 +810,7 @@ export default function SellerDashboard() {
             </Card>
 
             {/* Recent Offers */}
-            {pendingOffers.length === 0 && recentOffersCard}
+            {actionOffers.length === 0 && recentOffersCard}
           </TabsContent>
           
           

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1740,7 +1740,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
         return res.status(403).json({ message: "Forbidden" });
       }
 
-      if (offer.status !== 'pending') {
+      if (!['pending', 'countered'].includes(offer.status)) {
         return res.status(400).json({ message: "Offer already processed" });
       }
 
@@ -1874,7 +1874,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       const seller = await storage.getUser(offer.sellerId);
       const product = await storage.getProduct(offer.productId);
       if (seller && product) {
-        const priceOffered = offer.price + offer.serviceFee;
+        const priceOffered = offer.price;
         sendCounterAcceptedEmail(
           seller.email,
           product.title,
@@ -1919,7 +1919,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       const seller = await storage.getUser(offer.sellerId);
       const product = await storage.getProduct(offer.productId);
       if (seller && product) {
-        const priceOffered = offer.price + offer.serviceFee;
+        const priceOffered = offer.price;
         sendCounterRejectedEmail(
           seller.email,
           product.title,
@@ -1982,7 +1982,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
       const seller = await storage.getUser(offer.sellerId);
       if (seller) {
-        const priceOffered = price; // buyer offered price includes fee
+        const priceOffered = updated.price;
         sendCounterOfferEmail(
           seller.email,
           product.title,


### PR DESCRIPTION
## Summary
- show offers tab on seller dashboard again and surface countered offers
- allow sellers to counter an offer multiple times
- email sellers counter offer values without service fee

## Testing
- `npm --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68766d4abefc833087d1d356578378f1