### PR TITLE
Fix counter offer flow and price/unit labels

### DIFF
--- a/client/src/components/cart/cart-drawer.tsx
+++ b/client/src/components/cart/cart-drawer.tsx
@@ -84,7 +84,7 @@ export default function CartDrawer() {
                     <div className="flex-1">
                       <p className="text-sm font-medium">{o.productTitle}</p>
                       <p className="text-xs text-gray-500">
-                        Qty {o.quantity} · {formatCurrency(o.price + (o.serviceFee ?? 0))}
+                        Qty {o.quantity} · {formatCurrency(o.price + (o.serviceFee ?? 0))}/unit
                       </p>
                     </div>
                     <Button size="sm" onClick={() => addOfferToCart(o)}>

--- a/client/src/components/products/make-offer-dialog.tsx
+++ b/client/src/components/products/make-offer-dialog.tsx
@@ -76,7 +76,7 @@ export default function MakeOfferDialog({
             </div>
           )}
           <div>
-            <label className="block text-sm font-medium mb-1">Offer Price</label>
+            <label className="block text-sm font-medium mb-1">Price/Unit</label>
               <Input
               type="number"
               value={price}

--- a/client/src/pages/buyer/offers.tsx
+++ b/client/src/pages/buyer/offers.tsx
@@ -152,7 +152,7 @@ export default function BuyerOffersPage() {
                             <p className="text-sm">Quantity: {o.quantity}</p>
                           </div>
                           <div className="text-right space-y-1">
-                            <p>{formatCurrency(o.price + (o.serviceFee ?? 0))}</p>
+                            <p>Price/Unit: {formatCurrency(o.price + (o.serviceFee ?? 0))}</p>
                             <span className="text-xs capitalize">{o.status}</span>
                           </div>
                         </div>

--- a/client/src/pages/seller/dashboard.tsx
+++ b/client/src/pages/seller/dashboard.tsx
@@ -107,7 +107,9 @@ export default function SellerDashboard() {
     enabled: !!user,
   });
 
-  const pendingOffers = offers.filter((o) => o.status === "pending");
+  const actionOffers = offers.filter(
+    (o) => o.status === "pending" || o.status === "countered",
+  );
 
   const recentOffersCard = (
     <Card>
@@ -116,11 +118,11 @@ export default function SellerDashboard() {
         <CardDescription>Offers from buyers</CardDescription>
       </CardHeader>
       <CardContent>
-        {pendingOffers.length === 0 ? (
+        {actionOffers.length === 0 ? (
           <p className="text-sm text-gray-500">No offers yet.</p>
         ) : (
           <div className="space-y-4">
-            {pendingOffers.slice(0, 5).map((o) => (
+            {actionOffers.slice(0, 5).map((o) => (
               <div key={o.id} className="border rounded-lg p-4 flex gap-4 justify-between">
                 {o.productImages?.[0] && (
                   <img
@@ -139,7 +141,7 @@ export default function SellerDashboard() {
                     </p>
                   )}
                   <p className="text-sm">Qty: {o.quantity}</p>
-                  <p className="text-sm">{formatCurrency(o.price)}</p>
+                  <p className="text-sm">Price/Unit: {formatCurrency(o.price)}</p>
                 </div>
                 <div className="space-x-2 flex items-start">
                   <Button
@@ -402,7 +404,7 @@ export default function SellerDashboard() {
               Welcome back, {user?.firstName}
             </p>
           </div>
-          <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+          <div className="grid grid-cols-2 sm:grid-cols-5 gap-2">
             <Link href="/seller/products" className="w-full">
               <Button variant="outline" className="flex items-center w-full justify-center text-xs sm:text-sm">
                 <Package className="mr-2 h-4 w-4" />
@@ -421,6 +423,12 @@ export default function SellerDashboard() {
                 Payouts
               </Button>
             </Link>
+            <Link href="/seller/offers" className="w-full">
+              <Button variant="outline" className="flex items-center w-full justify-center text-xs sm:text-sm">
+                <TrendingUp className="mr-2 h-4 w-4" />
+                Offers
+              </Button>
+            </Link>
             <Link href="/seller/products?action=new" className="w-full">
               <Button className="flex items-center w-full justify-center text-xs sm:text-sm">
                 <PlusCircle className="mr-2 h-4 w-4" />
@@ -431,7 +439,7 @@ export default function SellerDashboard() {
         </div>
         
         <TabsContent value="overview" className="space-y-6">
-            {pendingOffers.length > 0 && recentOffersCard}
+            {actionOffers.length > 0 && recentOffersCard}
             {/* Stats Cards */}
             <div className="grid grid-cols-1 md:grid-cols-4 gap-6">
               <Card>
@@ -802,7 +810,7 @@ export default function SellerDashboard() {
             </Card>
 
             {/* Recent Offers */}
-            {pendingOffers.length === 0 && recentOffersCard}
+            {actionOffers.length === 0 && recentOffersCard}
           </TabsContent>
           
           

--- a/client/src/pages/seller/offers.tsx
+++ b/client/src/pages/seller/offers.tsx
@@ -148,7 +148,7 @@ export default function SellerOffersPage() {
                               </p>
                             )}
                             <p className="text-sm">Quantity: {o.quantity}</p>
-                            <p className="text-sm">Price: {formatCurrency(o.price)}</p>
+                            <p className="text-sm">Price/Unit: {formatCurrency(o.price)}</p>
                           </div>
                           <div className="text-right space-y-1">
                             <span className="text-xs capitalize">{o.status}</span>

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1740,7 +1740,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
         return res.status(403).json({ message: "Forbidden" });
       }
 
-      if (offer.status !== 'pending') {
+      if (!['pending', 'countered'].includes(offer.status)) {
         return res.status(400).json({ message: "Offer already processed" });
       }
 
@@ -1788,7 +1788,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       if (user.role !== 'seller' || offer.sellerId !== user.id) {
         return res.status(403).json({ message: "Forbidden" });
       }
-      if (offer.status !== 'pending') {
+      if (!['pending', 'countered'].includes(offer.status)) {
         return res.status(400).json({ message: "Offer already processed" });
       }
 
@@ -1874,7 +1874,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       const seller = await storage.getUser(offer.sellerId);
       const product = await storage.getProduct(offer.productId);
       if (seller && product) {
-        const priceOffered = offer.price + offer.serviceFee;
+        const priceOffered = offer.price;
         sendCounterAcceptedEmail(
           seller.email,
           product.title,
@@ -1919,7 +1919,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       const seller = await storage.getUser(offer.sellerId);
       const product = await storage.getProduct(offer.productId);
       if (seller && product) {
-        const priceOffered = offer.price + offer.serviceFee;
+        const priceOffered = offer.price;
         sendCounterRejectedEmail(
           seller.email,
           product.title,
@@ -1982,7 +1982,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
       const seller = await storage.getUser(offer.sellerId);
       if (seller) {
-        const priceOffered = price; // buyer offered price includes fee
+        const priceOffered = updated.price;
         sendCounterOfferEmail(
           seller.email,
           product.title,
@@ -2012,7 +2012,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       if (user.role !== 'seller' || offer.sellerId !== user.id) {
         return res.status(403).json({ message: "Forbidden" });
       }
-      if (offer.status !== 'pending') {
+      if (!['pending', 'countered'].includes(offer.status)) {
         return res.status(400).json({ message: "Offer already processed" });
       }
 


### PR DESCRIPTION
## Summary
- allow seller actions on pending or countered offers
- email sellers counter offer net prices
- label price as "Price/Unit" in offer UI

## Testing
- `npm run check` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68766d4abefc833087d1d356578378f1