### PR TITLE
Fix offer email price for sellers

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -272,10 +272,12 @@ export async function registerRoutes(app: Express): Promise<Server> {
 
       const seller = await storage.getUser(product.sellerId);
       if (seller) {
+        // Show the seller the net price without the service fee
+        const netPrice = req.body.price - fee;
         sendNewOfferEmail(
           seller.email,
           product.title,
-          req.body.price,
+          netPrice,
           req.body.quantity,
         ).catch(console.error);
       }


### PR DESCRIPTION
## Summary
- show the offer price minus service fee in seller notification emails

## Testing
- `npm run check` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_68767b85e414833080a026d21e084ea9