### PR TITLE
Use admin logo as favicon

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -69,10 +69,10 @@ function SettingsLoader() {
     if (data) {
       document.title = data.siteTitle;
       const faviconEl = document.getElementById(
-        "site-favicon"
+        "site-favicon",
       ) as HTMLLinkElement | null;
-      if (faviconEl && data.favicon) {
-        faviconEl.href = data.favicon;
+      if (faviconEl) {
+        faviconEl.href = data.logo || "/generated-icon.png";
       }
     }
   }, [data]);

--- a/client/src/hooks/use-settings.tsx
+++ b/client/src/hooks/use-settings.tsx
@@ -5,7 +5,6 @@ export interface SiteSettings {
   commissionRate: number;
   logo?: string | null;
   siteTitle: string;
-  favicon?: string | null;
 }
 
 export const DEFAULT_SERVICE_FEE_RATE = 0.035;

--- a/client/src/pages/admin/settings.tsx
+++ b/client/src/pages/admin/settings.tsx
@@ -13,18 +13,14 @@ export default function AdminSettingsPage() {
   const [rate, setRate] = useState(0.035);
   const [logo, setLogo] = useState<string | null>(null);
   const [siteTitle, setSiteTitle] = useState("SY Closeouts - B2B Wholesale Liquidation Marketplace");
-  const [favicon, setFavicon] = useState<string | null>(null);
   const logoFileRef = useRef<HTMLInputElement | null>(null);
-  const faviconFileRef = useRef<HTMLInputElement | null>(null);
   const [uploadingLogo, setUploadingLogo] = useState(false);
-  const [uploadingFavicon, setUploadingFavicon] = useState(false);
 
   useEffect(() => {
     if (data) {
       setRate(data.commissionRate);
       setLogo(data.logo ?? null);
       setSiteTitle(data.siteTitle);
-      setFavicon(data.favicon ?? null);
     }
   }, [data]);
 
@@ -43,30 +39,13 @@ export default function AdminSettingsPage() {
     reader.readAsDataURL(file);
   };
 
-  const handleFaviconFile = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (!file) return;
-    setUploadingFavicon(true);
-    const reader = new FileReader();
-    reader.onload = ev => {
-      if (ev.target?.result) {
-        setFavicon(ev.target.result.toString());
-      }
-      setUploadingFavicon(false);
-    };
-    reader.onerror = () => setUploadingFavicon(false);
-    reader.readAsDataURL(file);
-  };
-
   const triggerLogo = () => logoFileRef.current?.click();
-  const triggerFavicon = () => faviconFileRef.current?.click();
 
   const save = () => {
     update.mutate({
       commissionRate: rate,
       logo,
       siteTitle,
-      favicon,
     });
   };
 
@@ -108,15 +87,6 @@ export default function AdminSettingsPage() {
             <div>
               <label className="block text-sm font-medium mb-1">Site Title</label>
               <Input value={siteTitle} onChange={e => setSiteTitle(e.target.value)} />
-            </div>
-            <div>
-              <label className="block text-sm font-medium mb-1">Favicon</label>
-              {favicon && <img src={favicon} alt="Favicon" className="h-8 w-8 mb-2" />}
-              <Input value={favicon || ""} onChange={e => setFavicon(e.target.value)} placeholder="Image URL or data" />
-              <input type="file" ref={faviconFileRef} className="hidden" accept="image/*" onChange={handleFaviconFile} />
-              <Button type="button" variant="outline" className="mt-2" onClick={triggerFavicon} disabled={uploadingFavicon}>
-                {uploadingFavicon ? (<><Loader2 className="mr-2 h-4 w-4 animate-spin"/>Uploading...</>) : (<><ImagePlus className="mr-2 h-4 w-4"/>Upload Image</>)}
-              </Button>
             </div>
             <Button onClick={save} disabled={update.isPending}>
               {update.isPending ? (<><Loader2 className="mr-2 h-4 w-4 animate-spin"/>Saving...</>) : "Save"}

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1192,8 +1192,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       const title =
         (await storage.getSiteSetting("site_title")) ||
         "SY Closeouts - B2B Wholesale Liquidation Marketplace";
-      const favicon = await storage.getSiteSetting("favicon");
-      res.json({ commissionRate: rate, logo, siteTitle: title, favicon });
+      res.json({ commissionRate: rate, logo, siteTitle: title, favicon: logo });
     } catch (error) {
       handleApiError(res, error);
     }
@@ -1206,8 +1205,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       const title =
         (await storage.getSiteSetting("site_title")) ||
         "SY Closeouts - B2B Wholesale Liquidation Marketplace";
-      const favicon = await storage.getSiteSetting("favicon");
-      res.json({ commissionRate: rate, logo, siteTitle: title, favicon });
+      res.json({ commissionRate: rate, logo, siteTitle: title, favicon: logo });
     } catch (error) {
       handleApiError(res, error);
     }
@@ -1223,9 +1221,6 @@ export async function registerRoutes(app: Express): Promise<Server> {
       }
       if (req.body.siteTitle !== undefined) {
         await storage.setSiteSetting("site_title", req.body.siteTitle ?? "");
-      }
-      if (req.body.favicon !== undefined) {
-        await storage.setSiteSetting("favicon", req.body.favicon ?? "");
       }
       res.sendStatus(204);
     } catch (error) {


### PR DESCRIPTION
## Summary
- update favicon logic to rely on the configured logo
- remove separate favicon field from admin settings
- clean up settings API to return logo as favicon

## Testing
- `npm run check` *(fails: cannot find module types, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68767f6a0064833097ce93ac5450bc08