### PR TITLE
Restore home page for guests

### DIFF
--- a/client/src/pages/home-page.tsx
+++ b/client/src/pages/home-page.tsx
@@ -31,6 +31,7 @@ export default function HomePage() {
     if (user.role === "buyer") {
       return <Redirect to="/buyer/home" />;
     }
+    return <Redirect to="/products" />;
   }
 
   return (


### PR DESCRIPTION
## Summary
- restore original redirect logic in the home page so authenticated users go to their dashboards
- keep the home page visible for unauthenticated visitors

## Testing
- `npm run check` *(fails: missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68767e1bf49883309aa079b121a2b63d