### PR TITLE
Remove testimonials and update CTA copy

### DIFF
--- a/client/src/components/home/cta.tsx
+++ b/client/src/components/home/cta.tsx
@@ -13,7 +13,7 @@ export default function CTA() {
                 <span className="block">Sign up today.</span>
               </h2>
               <p className="mt-4 text-lg leading-6 text-blue-100">
-                Join thousands of businesses already using SY Closeouts to buy and sell wholesale inventory. Create your free account in minutes.
+                Don't get left behind—create your free SY Closeouts account in minutes.
               </p>
               <div className="mt-8 flex space-x-4">
                 <Link href="/auth?type=buyer">

--- a/client/src/pages/home-page.tsx
+++ b/client/src/pages/home-page.tsx
@@ -2,7 +2,6 @@ import Hero from "@/components/home/hero";
 import FeaturedProducts from "@/components/home/featured-products";
 import Features from "@/components/home/features";
 import SellWithUs from "@/components/home/sell-with-us";
-import Testimonials from "@/components/home/testimonials";
 import CTA from "@/components/home/cta";
 import Header from "@/components/layout/header-fixed";
 import Footer from "@/components/layout/footer-fixed";
@@ -42,7 +41,6 @@ export default function HomePage() {
         <FeaturedProducts />
         <Features />
         <SellWithUs />
-        <Testimonials />
         <CTA />
       </main>
       <Footer />


### PR DESCRIPTION
## Summary
- remove Testimonials section from the home page
- revise CTA text to avoid claiming thousands of businesses

## Testing
- `npm run check` *(fails: cannot find module errors)*

------
https://chatgpt.com/codex/tasks/task_e_687686592c5c833082c5a97ce94e173b