### PR TITLE
Fix bulk product upload shipping fields

### DIFF
--- a/client/public/product-template.csv
+++ b/client/public/product-template.csv
@@ -1,2 +1,2 @@
-title,description,category,price,totalUnits,availableUnits,minOrderQuantity,orderMultiple,images,fobLocation,retailComparisonUrl,upc,condition,isBanner
-Sample Product,"This is a sample product.",Electronics,9.99,100,100,1,1,https://example.com/image1.jpg|https://example.com/image2.jpg,"New York, NY",https://example.com,123456789012,New,false
+title,description,category,price,totalUnits,availableUnits,minOrderQuantity,orderMultiple,images,fobLocation,retailComparisonUrl,upc,condition,shippingType,shippingResponsibility,shippingFee,isBanner
+Sample Product,"This is a sample product.",Electronics,9.99,100,100,1,1,https://example.com/image1.jpg|https://example.com/image2.jpg,"New York, NY",https://example.com,123456789012,New,truckload,seller_free,,false

--- a/client/src/components/seller/bulk-upload.tsx
+++ b/client/src/components/seller/bulk-upload.tsx
@@ -32,7 +32,10 @@ function parseCsv(text: string): Omit<InsertProduct, "sellerId">[] {
     if (row.availableUnits !== undefined) row.availableUnits = parseInt(row.availableUnits, 10);
     if (row.minOrderQuantity !== undefined) row.minOrderQuantity = parseInt(row.minOrderQuantity, 10);
     if (row.orderMultiple !== undefined) row.orderMultiple = parseInt(row.orderMultiple, 10);
+    if (row.shippingFee !== undefined) row.shippingFee = row.shippingFee === "" ? undefined : parseFloat(row.shippingFee);
     if (row.isBanner !== undefined) row.isBanner = row.isBanner === "true";
+    if (!row.shippingType) row.shippingType = "truckload";
+    if (!row.shippingResponsibility) row.shippingResponsibility = "seller_free";
     return row as Omit<InsertProduct, "sellerId">;
   });
 }


### PR DESCRIPTION
## Summary
- handle shipping info during CSV import
- add shipping columns to CSV template

## Testing
- `npm run check` *(fails: Cannot find module 'vite' and others)*

------
https://chatgpt.com/codex/tasks/task_e_687697b958ac8330bfd0295fe61cbc70