### PR TITLE
Require resale cert and allow sellers to buy

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -108,7 +108,7 @@ function Router() {
       <ProtectedRoute path="/buyer/home" component={BuyerHomePage} allowedRoles={["buyer", "admin"]} />
       <ProtectedRoute path="/buyer/orders" component={BuyerOrdersPage} allowedRoles={["buyer", "admin"]} />
       <ProtectedRoute path="/buyer/messages" component={BuyerMessagesPage} allowedRoles={["buyer", "admin"]} />
-      <ProtectedRoute path="/buyer/offers" component={BuyerOffersPage} allowedRoles={["buyer", "admin"]} />
+      <ProtectedRoute path="/buyer/offers" component={BuyerOffersPage} allowedRoles={["buyer", "seller", "admin"]} />
       <ProtectedRoute path="/buyer/orders/:id" component={BuyerOrderDetailPage} allowedRoles={["buyer", "admin"]} />
       <ProtectedRoute path="/buyer/profile" component={BuyerProfilePage} allowedRoles={["buyer", "admin"]} />
 

--- a/client/src/components/layout/header-fixed.tsx
+++ b/client/src/components/layout/header-fixed.tsx
@@ -69,7 +69,7 @@ export default function Header() {
                   user?.role === 'admin' && { label: 'Admin', href: '/admin/dashboard' },
                   user?.role === 'admin' && { label: 'Tickets', href: '/admin/tickets' },
                   user?.role === 'buyer' && { label: 'My Orders', href: '/buyer/orders' },
-                  user?.role === 'buyer' && { label: 'Offers', href: '/buyer/offers' },
+                  (user?.role === 'buyer' || user?.role === 'seller') && { label: 'Offers', href: '/buyer/offers' },
                   user?.role === 'seller'
                     ? { label: 'Dashboard', href: '/seller/dashboard' }
                     : !user || user.role === 'buyer'

--- a/client/src/components/layout/header.tsx
+++ b/client/src/components/layout/header.tsx
@@ -78,7 +78,7 @@ export default function Header({ dashboardTabs, onProfileClick }: HeaderProps) {
                     label: "My Orders",
                     href: "/buyer/orders",
                   },
-                  user?.role === "buyer" && {
+                  (user?.role === "buyer" || user?.role === "seller") && {
                     label: "Offers",
                     href: "/buyer/offers",
                   },

--- a/client/src/components/layout/mobile-nav.tsx
+++ b/client/src/components/layout/mobile-nav.tsx
@@ -52,7 +52,7 @@ export default function MobileNav() {
             </Link>
           </li>
         )}
-        {user?.role === "buyer" && (
+        {(user?.role === "buyer" || user?.role === "seller") && (
           <li>
             <Link
               href="/buyer/offers"

--- a/client/src/hooks/use-auth.tsx
+++ b/client/src/hooks/use-auth.tsx
@@ -43,13 +43,20 @@ export const registerSchemaBase = z.object({
 });
 
 // Registration schema used on the signup page with password confirmation check
-export const registerSchema = registerSchemaBase.refine(
-  (data) => data.password === data.confirmPassword,
-  {
+export const registerSchema = registerSchemaBase
+  .refine((data) => data.password === data.confirmPassword, {
     message: "Passwords don't match",
     path: ["confirmPassword"],
-  }
-);
+  })
+  .refine(
+    (data) =>
+      data.role !== "buyer" ||
+      (typeof data.resaleCertUrl === "string" && data.resaleCertUrl.trim() !== ""),
+    {
+      message: "Resale certificate is required",
+      path: ["resaleCertUrl"],
+    }
+  );
 
 type AuthContextType = {
   user: User | null;

--- a/client/src/pages/product-detail-page.tsx
+++ b/client/src/pages/product-detail-page.tsx
@@ -328,7 +328,7 @@ export default function ProductDetailPage() {
               Add to Cart
             </Button>
 
-            {user?.role === "buyer" && (
+            {(user?.role === "buyer" || user?.role === "seller") && (
               <>
                 <MakeOfferDialog
                   onSubmit={(p, q) =>

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -135,6 +135,10 @@ export function setupAuth(app: Express) {
         ...userFields
       } = req.body;
 
+      if (userFields.role === "buyer" && !resaleCertUrl) {
+        return res.status(400).json({ error: "Resale certificate is required" });
+      }
+
       const resaleCertStatus = resaleCertUrl ? "pending" : "none";
 
       const user = await storage.createUser({

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -232,8 +232,8 @@ export async function registerRoutes(app: Express): Promise<Server> {
         return res.status(400).json({ message: "Invalid product ID" });
       }
       const user = req.user as Express.User;
-      if (user.role !== "buyer") {
-        return res.status(403).json({ message: "Only buyers can send offers" });
+      if (user.role !== "buyer" && user.role !== "seller") {
+        return res.status(403).json({ message: "Only buyers or sellers can send offers" });
       }
       const product = await storage.getProduct(id);
       if (!product) {


### PR DESCRIPTION
## Summary
- demand resale certificate when buyers register
- let buyers and sellers send offers for a product
- allow sellers to see Offer actions and ask questions like buyers
- expose buyer offers page for sellers

## Testing
- `npm run check` *(fails: Cannot find module 'wouter' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68782a7d2bd883309b2c1b2fbac0c23f