### PR TITLE
Enable admin user deletion

### DIFF
--- a/client/src/hooks/use-users.tsx
+++ b/client/src/hooks/use-users.tsx
@@ -1,0 +1,12 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { apiRequest } from "@/lib/queryClient";
+
+export function useDeleteUser() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: number) => apiRequest("DELETE", `/api/users/${id}`),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["/api/users"] });
+    },
+  });
+}

--- a/client/src/pages/admin/user-profile.tsx
+++ b/client/src/pages/admin/user-profile.tsx
@@ -31,6 +31,7 @@ import ChatMessage from "@/components/messages/chat-message";
 import { useAdminUserMessages } from "@/hooks/use-messages";
 import { useUserNotes, useCreateUserNote } from "@/hooks/use-user-notes";
 import { Textarea } from "@/components/ui/textarea";
+import { useDeleteUser } from "@/hooks/use-users";
 
 export default function AdminUserProfilePage() {
   const { id } = useParams();
@@ -83,6 +84,8 @@ export default function AdminUserProfilePage() {
       queryClient.invalidateQueries({ queryKey: ["/api/users/" + userId] });
     },
   });
+
+  const deleteUserMutation = useDeleteUser();
 
   const [certStatus, setCertStatus] = useState<string>("pending");
   const updateCertStatus = useMutation({
@@ -282,6 +285,29 @@ export default function AdminUserProfilePage() {
                     Reinstate Now
                   </Button>
                 )}
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle>Delete User</CardTitle>
+              </CardHeader>
+              <CardContent>
+                <Button
+                  variant="destructive"
+                  onClick={() => {
+                    if (confirm("Delete this user?")) {
+                      deleteUserMutation.mutate(userId, {
+                        onSuccess: () => {
+                          window.location.href = "/admin/users";
+                        },
+                      });
+                    }
+                  }}
+                  disabled={deleteUserMutation.isPending}
+                >
+                  Delete User
+                </Button>
               </CardContent>
             </Card>
 

--- a/client/src/pages/admin/users.tsx
+++ b/client/src/pages/admin/users.tsx
@@ -52,8 +52,10 @@ import {
   FilterX,
   Mail,
   ShieldCheck,
-  ShieldX
+  ShieldX,
+  Trash2
 } from "lucide-react";
+import { useDeleteUser } from "@/hooks/use-users";
 
 export default function AdminUsers() {
   const { toast } = useToast();
@@ -146,6 +148,8 @@ export default function AdminUsers() {
       }
     });
   };
+
+  const deleteUser = useDeleteUser();
   
   const clearFilters = () => {
     setSearchTerm("");
@@ -331,9 +335,9 @@ export default function AdminUsers() {
                             )}
                             
                             {user.role === "seller" && user.isApproved && (
-                              <Button 
-                                size="sm" 
-                                variant="outline" 
+                              <Button
+                                size="sm"
+                                variant="outline"
                                 onClick={() => handleRevokeSeller(user)}
                                 disabled={isUpdating}
                                 className="h-8 px-2 flex items-center text-red-600 border-red-200 hover:bg-red-50"
@@ -342,6 +346,20 @@ export default function AdminUsers() {
                                 Revoke
                               </Button>
                             )}
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              onClick={() => {
+                                if (confirm("Delete this user?")) {
+                                  deleteUser.mutate(user.id);
+                                }
+                              }}
+                              disabled={deleteUser.isPending}
+                              className="h-8 px-2 flex items-center text-red-600 border-red-200 hover:bg-red-50"
+                            >
+                              <Trash2 className="h-4 w-4 mr-1" />
+                              Delete
+                            </Button>
                           </div>
                         </TableCell>
                       </TableRow>

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -2261,6 +2261,25 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
+  app.delete("/api/users/:id", isAuthenticated, isAdmin, async (req, res) => {
+    try {
+      const id = parseInt(req.params.id, 10);
+      if (Number.isNaN(id)) {
+        return res.status(400).json({ message: "Invalid user ID" });
+      }
+
+      const user = await storage.getUser(id);
+      if (!user) {
+        return res.status(404).json({ message: "User not found" });
+      }
+
+      await storage.deleteUser(id);
+      res.sendStatus(204);
+    } catch (error) {
+      handleApiError(res, error);
+    }
+  });
+
   app.get("/api/users/:id", isAuthenticated, async (req, res) => {
     try {
       const id = parseInt(req.params.id, 10);

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -37,6 +37,7 @@ export interface IStorage {
   createUser(user: InsertUser): Promise<User>;
   updateUser(id: number, user: Partial<User>): Promise<User | undefined>;
   getUsers(): Promise<User[]>;
+  deleteUser(id: number): Promise<void>;
   
   // Product methods
   getProduct(id: number): Promise<Product | undefined>;
@@ -206,6 +207,21 @@ export class DatabaseStorage implements IStorage {
 
   async getUsers(): Promise<User[]> {
     return await db.select().from(users);
+  }
+
+  async deleteUser(id: number): Promise<void> {
+    await db.transaction(async (tx) => {
+      await tx
+        .delete(userNotes)
+        .where(
+          or(
+            eq(userNotes.userId, id),
+            eq(userNotes.adminId, id),
+            eq(userNotes.relatedUserId, id),
+          )
+        );
+      await tx.delete(users).where(eq(users.id, id));
+    });
   }
 
   // Product methods


### PR DESCRIPTION
## Summary
- allow admins to delete users via API
- expose `deleteUser` storage helper
- add delete user button to admin user list and profile pages
- provide React hook for deleting users
- clear user notes before removing user to avoid FK errors

## Testing
- `npm run check` *(fails: npm not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e7bab4ee48330a0a8ac8db9562c46