### PR TITLE
Add bulk email group selection

### DIFF
--- a/client/src/pages/admin/email-templates.tsx
+++ b/client/src/pages/admin/email-templates.tsx
@@ -50,6 +50,7 @@ export default function AdminEmailTemplatesPage() {
 
   const [search, setSearch] = useState("");
   const [selectedUsers, setSelectedUsers] = useState<User[]>([]);
+  const [group, setGroup] = useState("");
   const [templateId, setTemplateId] = useState<number>();
   const [creatingNew, setCreatingNew] = useState(false);
   const [name, setName] = useState("");
@@ -107,6 +108,12 @@ export default function AdminEmailTemplatesPage() {
 
   const sendEmail = useMutation({
     mutationFn: async () => {
+      if (group && templateId) {
+        await apiRequest("POST", `/api/admin/email-templates/${templateId}/send`, {
+          group,
+        });
+        return;
+      }
       for (const u of selectedUsers) {
         const html = applyPlaceholders(body, u);
         await apiRequest(`POST`, `/api/admin/users/${u.id}/email`, {
@@ -147,6 +154,16 @@ export default function AdminEmailTemplatesPage() {
               value={search}
               onChange={e => setSearch(e.target.value)}
             />
+            <Select value={group} onValueChange={setGroup}>
+              <SelectTrigger className="w-[200px]">
+                <SelectValue placeholder="Send to group..." />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="buyers">All Buyers</SelectItem>
+                <SelectItem value="sellers">All Sellers</SelectItem>
+                <SelectItem value="both">Buyers &amp; Sellers</SelectItem>
+              </SelectContent>
+            </Select>
             {search && (
               <div className="border rounded p-2 max-h-40 overflow-y-auto bg-white shadow">
                 {users
@@ -237,7 +254,7 @@ export default function AdminEmailTemplatesPage() {
               className="border rounded p-4 bg-white shadow"
               dangerouslySetInnerHTML={{ __html: buildPreview() }}
             />
-            <Button onClick={() => sendEmail.mutate()} disabled={sendEmail.isPending || selectedUsers.length === 0}>
+            <Button onClick={() => sendEmail.mutate()} disabled={sendEmail.isPending || (selectedUsers.length === 0 && !group)}>
               Send Email
             </Button>
           </CardContent>

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1104,13 +1104,13 @@ export async function registerRoutes(app: Express): Promise<Server> {
     try {
       const id = parseInt(req.params.id, 10);
       const group = req.body.group as string;
-      if (Number.isNaN(id) || (group !== "buyers" && group !== "sellers")) {
+      if (Number.isNaN(id) || !["buyers", "sellers", "both"].includes(group)) {
         return res.status(400).json({ message: "Invalid parameters" });
       }
       const template = await storage.getEmailTemplate(id);
       if (!template) return res.status(404).json({ message: "Template not found" });
-      const users = await storage.getUsers();
-      const targets = users.filter(u => u.role === (group === "buyers" ? "buyer" : "seller"));
+      const roles = group === "buyers" ? ["buyer"] : group === "sellers" ? ["seller"] : ["buyer", "seller"];
+      const targets = await storage.getUsers({ roles });
       for (const u of targets) {
         const html = template.body
           .replace(/\[first_name\]/gi, u.firstName)

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -21,7 +21,7 @@ import {
 } from "@shared/schema";
 import session from "express-session";
 import { db, pool } from "./db";
-import { eq, and, or, desc, SQL, ilike, lte, gte, sql } from "drizzle-orm";
+import { eq, and, or, desc, SQL, ilike, lte, gte, sql, inArray } from "drizzle-orm";
 import connectPgSimple from "connect-pg-simple";
 import { generateOrderCode } from "./orderCode";
 import { randomBytes } from "crypto";
@@ -36,7 +36,7 @@ export interface IStorage {
   getUserByEmail(email: string): Promise<User | undefined>;
   createUser(user: InsertUser): Promise<User>;
   updateUser(id: number, user: Partial<User>): Promise<User | undefined>;
-  getUsers(): Promise<User[]>;
+  getUsers(filter?: { roles?: string[] }): Promise<User[]>;
   deleteUser(id: number): Promise<void>;
   
   // Product methods
@@ -205,7 +205,10 @@ export class DatabaseStorage implements IStorage {
     return updatedUser;
   }
 
-  async getUsers(): Promise<User[]> {
+  async getUsers(filter?: { roles?: string[] }): Promise<User[]> {
+    if (filter?.roles && filter.roles.length > 0) {
+      return await db.select().from(users).where(inArray(users.role, filter.roles));
+    }
     return await db.select().from(users);
   }
 


### PR DESCRIPTION
## Summary
- support filtering users by role in storage layer
- allow specifying buyers, sellers or both when sending email templates
- add group dropdown in admin email template page

## Testing
- `npm run check` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_6881897dd98c8330a67185e489ae7981