### PR TITLE
Enable email login

### DIFF
--- a/client/src/hooks/use-auth.tsx
+++ b/client/src/hooks/use-auth.tsx
@@ -11,7 +11,7 @@ import { z } from "zod";
 
 // Create a login schema manually since insertUserSchema is already processed
 export const loginSchema = z.object({
-  username: z.string().min(1, "Username is required"),
+  username: z.string().min(1, "Username or email is required"),
   password: z.string().min(6, "Password must be at least 6 characters long"),
 });
 

--- a/client/src/pages/auth-page.tsx
+++ b/client/src/pages/auth-page.tsx
@@ -105,9 +105,9 @@ export default function AuthPage() {
                       name="username"
                       render={({ field }) => (
                         <FormItem>
-                          <FormLabel>Username</FormLabel>
+                          <FormLabel>Username or Email</FormLabel>
                           <FormControl>
-                            <Input placeholder="Enter your username" {...field} />
+                            <Input placeholder="Enter your username or email" {...field} />
                           </FormControl>
                           <FormMessage />
                         </FormItem>

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -72,7 +72,11 @@ export function setupAuth(app: Express) {
   passport.use(
     new LocalStrategy(async (username: string, password: string, done) => {
       try {
-        const user = await storage.getUserByUsername(username);
+        const identifier = username.toLowerCase();
+        let user = await storage.getUserByUsername(identifier);
+        if (!user) {
+          user = await storage.getUserByEmail(identifier);
+        }
         if (!user || !(await comparePasswords(password, user.password))) {
           return done(null, false, { message: "Invalid username or password" });
         }

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -182,24 +182,38 @@ export class DatabaseStorage implements IStorage {
   }
 
   async getUserByUsername(username: string): Promise<User | undefined> {
-    const [user] = await db.select().from(users).where(eq(users.username, username));
+    const [user] = await db
+      .select()
+      .from(users)
+      .where(eq(users.username, username.toLowerCase()));
     return user;
   }
 
   async getUserByEmail(email: string): Promise<User | undefined> {
-    const [user] = await db.select().from(users).where(eq(users.email, email));
+    const [user] = await db
+      .select()
+      .from(users)
+      .where(eq(users.email, email.toLowerCase()));
     return user;
   }
 
   async createUser(insertUser: InsertUser): Promise<User> {
-    const [user] = await db.insert(users).values(insertUser).returning();
+    const normalized = {
+      ...insertUser,
+      username: insertUser.username.toLowerCase(),
+      email: insertUser.email.toLowerCase(),
+    };
+    const [user] = await db.insert(users).values(normalized).returning();
     return user;
   }
 
   async updateUser(id: number, userData: Partial<User>): Promise<User | undefined> {
+    const normalized: Partial<User> = { ...userData };
+    if (normalized.username) normalized.username = normalized.username.toLowerCase();
+    if (normalized.email) normalized.email = normalized.email.toLowerCase();
     const [updatedUser] = await db
       .update(users)
-      .set(userData)
+      .set(normalized)
       .where(eq(users.id, id))
       .returning();
     return updatedUser;


### PR DESCRIPTION
## Summary
- accept username or email in the login form
- make LocalStrategy match either username or email in a case-insensitive way
- normalize username/email when storing and retrieving users

## Testing
- `npm run check` *(fails: tsc not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881960000c0833089f2cd3d80dd5a4a