### PR TITLE
Revamp admin message supervision

### DIFF
--- a/client/src/hooks/use-messages.tsx
+++ b/client/src/hooks/use-messages.tsx
@@ -63,6 +63,12 @@ export function useAdminUserMessages(userId: number) {
   });
 }
 
+export function useAdminRecentMessages(limit = 100) {
+  return useQuery<any[]>({
+    queryKey: [`/api/admin/messages?limit=${limit}`],
+  });
+}
+
 export function useUnreadMessages() {
   const { data } = useQuery<{ count: number }>({
     queryKey: ["/api/messages/unread-count"],

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1004,6 +1004,21 @@ export async function registerRoutes(app: Express): Promise<Server> {
   );
 
   app.get(
+    "/api/admin/messages",
+    isAuthenticated,
+    isAdmin,
+    async (req, res) => {
+      try {
+        const limit = parseInt(String(req.query.limit || "100"), 10);
+        const msgs = await storage.getRecentMessages(limit);
+        res.json(msgs);
+      } catch (error) {
+        handleApiError(res, error);
+      }
+    },
+  );
+
+  app.get(
     "/api/admin/users/:userId/orders",
     isAuthenticated,
     isAdmin,

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -630,6 +630,14 @@ export class DatabaseStorage implements IStorage {
       .orderBy(messages.createdAt);
   }
 
+  async getRecentMessages(limit: number): Promise<any[]> {
+    const result = await pool.query(
+      `SELECT m.*,\n              s.first_name AS sender_first_name, s.last_name AS sender_last_name, s.username AS sender_username,\n              r.first_name AS receiver_first_name, r.last_name AS receiver_last_name, r.username AS receiver_username\n         FROM messages m\n         JOIN users s ON s.id = m.sender_id\n         JOIN users r ON r.id = m.receiver_id\n        ORDER BY m.created_at DESC\n        LIMIT $1`,
+      [limit],
+    );
+    return result.rows;
+  }
+
   // Product question methods
   async createProductQuestion(insertQuestion: InsertProductQuestion): Promise<ProductQuestion> {
     const [q] = await db.insert(productQuestions).values(insertQuestion).returning();


### PR DESCRIPTION
## Summary
- add storage helper to list recent messages
- expose new `/api/admin/messages` route
- add `useAdminRecentMessages` hook
- show recent messages in admin as a table

## Testing
- `npm run check` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6882b325e29c8330b6d624fa0a10a877