### PR TITLE
Add CSV export for admin inventory and user lists

### DIFF
--- a/client/src/pages/admin/products.tsx
+++ b/client/src/pages/admin/products.tsx
@@ -225,14 +225,19 @@ export default function AdminProducts() {
           <CardHeader>
             <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
               <CardTitle>Product Inventory</CardTitle>
-              <div className="relative">
-                <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 h-4 w-4" />
-                <Input
-                  placeholder="Search products..."
-                  className="pl-10 w-full md:w-[300px]"
-                  value={searchTerm}
-                  onChange={(e) => setSearchTerm(e.target.value)}
-                />
+              <div className="flex flex-col sm:flex-row gap-3">
+                <div className="relative">
+                  <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-gray-400 h-4 w-4" />
+                  <Input
+                    placeholder="Search products..."
+                    className="pl-10 w-full md:w-[300px]"
+                    value={searchTerm}
+                    onChange={(e) => setSearchTerm(e.target.value)}
+                  />
+                </div>
+                <Button variant="outline" asChild>
+                  <a href="/api/products.csv" download>Export CSV</a>
+                </Button>
               </div>
             </div>
           </CardHeader>

--- a/client/src/pages/admin/users.tsx
+++ b/client/src/pages/admin/users.tsx
@@ -224,6 +224,13 @@ export default function AdminUsers() {
                     <SelectItem value="pending">Pending</SelectItem>
                   </SelectContent>
                 </Select>
+
+                <Button variant="outline" asChild>
+                  <a href="/api/users.csv?role=buyer" download>Export Buyers</a>
+                </Button>
+                <Button variant="outline" asChild>
+                  <a href="/api/users.csv?role=seller" download>Export Sellers</a>
+                </Button>
                 
                 {(searchTerm || roleFilter !== "all" || statusFilter !== "all") && (
                   <Button 

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -149,6 +149,34 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
+  app.get("/api/products.csv", isAuthenticated, isAdmin, async (_req, res) => {
+    try {
+      const products = await storage.getProducts();
+      const records = products as Record<string, unknown>[];
+
+      const headers = records.length > 0 ? Object.keys(records[0]) : [];
+
+      const escapeCsv = (val: unknown) => {
+        if (val === null || val === undefined) return "";
+        const str = Array.isArray(val) ? JSON.stringify(val) : String(val);
+        return /[",\n]/.test(str) ? '"' + str.replace(/"/g, '""') + '"' : str;
+      };
+
+      const lines = [
+        headers.join(","),
+        ...records.map((r) => headers.map((h) => escapeCsv((r as any)[h])).join(",")),
+      ];
+
+      const csv = lines.join("\n");
+
+      res.setHeader("Content-Type", "text/csv");
+      res.setHeader("Content-Disposition", "attachment; filename=products.csv");
+      res.send(csv);
+    } catch (error) {
+      handleApiError(res, error);
+    }
+  });
+
   app.get("/api/products/low-stock", isAuthenticated, isSeller, async (req, res) => {
     try {
       const threshold = parseInt(req.query.threshold as string, 10) || 5;
@@ -2175,10 +2203,12 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
-  app.get("/api/users.csv", isAuthenticated, isAdmin, async (_req, res) => {
+  app.get("/api/users.csv", isAuthenticated, isAdmin, async (req, res) => {
     try {
-      const buyersAndSellers = await storage.getUsers({ roles: ["buyer", "seller"] });
-      const records = buyersAndSellers.map(({ password, ...u }) => u);
+      const roleParam = (req.query.role as string | undefined)?.trim();
+      const roles = roleParam ? roleParam.split(',').map(r => r.trim()) : ["buyer", "seller"];
+      const usersForCsv = await storage.getUsers({ roles });
+      const records = usersForCsv.map(({ password, ...u }) => u);
 
       const headers = records.length > 0 ? Object.keys(records[0]) : [];
 


### PR DESCRIPTION
## Summary
- allow admins to download all products as `products.csv`
- extend `users.csv` API to filter by role
- add export buttons to Admin Products and Admin Users pages

## Testing
- `npm run check` *(fails: Module '@vitejs/plugin-react' not found)*

------
https://chatgpt.com/codex/tasks/task_e_68825f3b7ac88330a56bd20adffeb65b