### PR TITLE
Handle missing user info in email logs and add HTML upload

### DIFF
--- a/client/src/pages/admin/email-templates.tsx
+++ b/client/src/pages/admin/email-templates.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import React, { useState, useEffect } from "react";
 import Header from "@/components/layout/header";
 import Footer from "@/components/layout/footer";
 import {
@@ -58,6 +58,16 @@ export default function AdminEmailTemplatesPage() {
   const [body, setBody] = useState("");
   const { data: logs = [] } = useEmailLogs(templateId);
   const [openLog, setOpenLog] = useState<string | null>(null);
+  function handleHtmlUpload(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = evt => {
+      const text = evt.target?.result as string;
+      if (text) setBody(text);
+    };
+    reader.readAsText(file);
+  }
 
   useEffect(() => {
     if (templates.length > 0 && templateId === undefined && !creatingNew) {
@@ -240,6 +250,7 @@ export default function AdminEmailTemplatesPage() {
               value={subject}
               onChange={e => setSubject(e.target.value)}
             />
+            <input type="file" accept=".html" onChange={handleHtmlUpload} />
             <RichTextEditor value={body} onChange={setBody} />
             <Button
               variant="outline"
@@ -323,7 +334,9 @@ export default function AdminEmailTemplatesPage() {
                 <TableBody>
                   {logs.map(l => (
                     <TableRow key={l.id}>
-                      <TableCell>{l.user.firstName} {l.user.lastName}</TableCell>
+                      <TableCell>
+                        {l.user ? `${l.user.firstName} ${l.user.lastName}` : "Unknown"}
+                      </TableCell>
                       <TableCell>{new Date(l.createdAt).toLocaleString()}</TableCell>
                       <TableCell>
                         <Dialog open={openLog === String(l.id)} onOpenChange={o => !o && setOpenLog(null)}>


### PR DESCRIPTION
## Summary
- allow admins to upload HTML files when editing email templates
- show "Unknown" if an email log entry has no user

## Testing
- `npm run check` *(fails: Cannot find module 'lucide-react', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688b8dbb8d2c8330b19d552af47a880b