### PR TITLE
Fix bulk email sending and add success logs

### DIFF
--- a/client/src/pages/admin/email-templates.tsx
+++ b/client/src/pages/admin/email-templates.tsx
@@ -328,6 +328,7 @@ export default function AdminEmailTemplatesPage() {
                   <TableRow>
                     <TableHead>Recipient</TableHead>
                     <TableHead>Date</TableHead>
+                    <TableHead>Status</TableHead>
                     <TableHead>Actions</TableHead>
                   </TableRow>
                 </TableHeader>
@@ -338,6 +339,7 @@ export default function AdminEmailTemplatesPage() {
                         {l.user ? `${l.user.firstName} ${l.user.lastName}` : "Unknown"}
                       </TableCell>
                       <TableCell>{new Date(l.createdAt).toLocaleString()}</TableCell>
+                      <TableCell>{l.success ? "Success" : "Failed"}</TableCell>
                       <TableCell>
                         <Dialog open={openLog === String(l.id)} onOpenChange={o => !o && setOpenLog(null)}>
                           <DialogTrigger asChild>

--- a/server/email.ts
+++ b/server/email.ts
@@ -688,21 +688,21 @@ export async function sendStrikeEmail(
 }
 
 export async function sendAdminUserEmail(
-  to: string,
+  to: string | string[],
   subject: string,
   body: string,
   html?: string,
-) {
+): Promise<boolean> {
   if (!transporter) {
     console.warn("Email transport not configured; skipping admin user email");
-    return;
+    return false;
   }
 
   const logo = await getLogoAttachment();
   const finalHtml = wrapTemplate(subject, html ?? body.replace(/\n/g, "<br>"));
   const mailOptions = {
     from: process.env.SMTP_FROM || user,
-    to,
+    to: Array.isArray(to) ? to.join(",") : to,
     subject,
     text: (html ?? body).replace(/<[^>]*>/g, ""),
     html: finalHtml,
@@ -711,15 +711,21 @@ export async function sendAdminUserEmail(
 
   try {
     await transporter.sendMail(mailOptions);
+    return true;
   } catch (err) {
     console.error("Failed to send admin user email", err);
+    return false;
   }
 }
 
-export async function sendHtmlEmail(to: string, subject: string, html: string) {
+export async function sendHtmlEmail(
+  to: string | string[],
+  subject: string,
+  html: string,
+): Promise<boolean> {
   if (!transporter) {
     console.warn("Email transport not configured; skipping html email");
-    return;
+    return false;
   }
 
   const logo = await getLogoAttachment();
@@ -727,7 +733,7 @@ export async function sendHtmlEmail(to: string, subject: string, html: string) {
   const text = wrapped.replace(/<[^>]*>/g, "");
   const mailOptions = {
     from: process.env.SMTP_FROM || user,
-    to,
+    to: Array.isArray(to) ? to.join(",") : to,
     subject,
     text,
     html: wrapped,
@@ -736,8 +742,10 @@ export async function sendHtmlEmail(to: string, subject: string, html: string) {
 
   try {
     await transporter.sendMail(mailOptions);
+    return true;
   } catch (err) {
     console.error("Failed to send html email", err);
+    return false;
   }
 }
 

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1135,12 +1135,13 @@ export async function registerRoutes(app: Express): Promise<Server> {
           return res.status(400).json({ message: "Missing subject or message" });
         }
 
-        await sendAdminUserEmail(user.email, subject, message, html);
+        const success = await sendAdminUserEmail(user.email, subject, message, html);
         await storage.createEmailLog({
           templateId: req.body.templateId,
           userId: user.id,
           subject,
           html: html || message,
+          success,
         });
         res.sendStatus(204);
       } catch (error) {
@@ -1208,12 +1209,13 @@ export async function registerRoutes(app: Express): Promise<Server> {
           .replace(/\[last_name\]/gi, u.lastName)
           .replace(/\[name\]/gi, `${u.firstName} ${u.lastName}`)
           .replace(/\[company\]/gi, u.company || "");
-        await sendHtmlEmail(u.email, template.subject, html);
+        const success = await sendHtmlEmail(u.email, template.subject, html);
         await storage.createEmailLog({
           templateId: template.id,
           userId: u.id,
           subject: template.subject,
           html,
+          success,
         });
       }
       res.sendStatus(204);

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -926,6 +926,7 @@ export class DatabaseStorage implements IStorage {
       userId: r.user_id,
       subject: r.subject,
       html: r.html,
+      success: r.success,
       createdAt: r.created_at,
       user: {
         id: r.user_id,

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -476,6 +476,7 @@ export const emailLogs = pgTable("email_logs", {
     .references(() => users.id),
   subject: text("subject").notNull(),
   html: text("html").notNull(),
+  success: boolean("success").notNull().default(true),
   createdAt: timestamp("created_at").defaultNow(),
 });
 


### PR DESCRIPTION
## Summary
- allow sending HTML emails to multiple recipients
- record send success for admin emails
- display status column in email logs

## Testing
- `npm run check` *(fails: Cannot find module 'wouter' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_688b9be4be2c8330be5f2fd68c655041