### PR TITLE
Improve mobile navigation and quote action styling

### DIFF
--- a/client/src/components/layout/header-fixed.tsx
+++ b/client/src/components/layout/header-fixed.tsx
@@ -181,6 +181,7 @@ export default function Header() {
                 size="icon"
                 className="text-gray-400 hover:text-gray-500"
                 onClick={() => setIsMenuOpen(!isMenuOpen)}
+                type="button"
               >
                 <span className="sr-only">Open main menu</span>
                 {isMenuOpen ? <X className="h-6 w-6" /> : <Menu className="h-6 w-6" />}

--- a/client/src/components/layout/header.tsx
+++ b/client/src/components/layout/header.tsx
@@ -232,6 +232,7 @@ export default function Header({ dashboardTabs, onProfileClick }: HeaderProps) {
                 size="icon"
                 className="text-gray-400 hover:text-gray-500"
                 onClick={() => setIsMenuOpen(!isMenuOpen)}
+                type="button"
               >
                 <span className="sr-only">Open main menu</span>
                 {isMenuOpen ? <X className="h-6 w-6" /> : <Menu className="h-6 w-6" />}

--- a/client/src/components/layout/mobile-nav.tsx
+++ b/client/src/components/layout/mobile-nav.tsx
@@ -19,22 +19,22 @@ export default function MobileNav() {
   const isActive = (path: string) => location === path;
 
   return (
-      <nav className="fixed bottom-0 inset-x-0 z-50 border-t bg-white shadow pb-2 [padding-bottom:env(safe-area-inset-bottom)] sm:hidden">
+    <nav className="fixed bottom-0 inset-x-0 z-50 border-t bg-white shadow pb-2 [padding-bottom:env(safe-area-inset-bottom)] sm:hidden">
       <ul className="flex justify-around p-2">
-        <li>
+        <li className="flex-1">
           <Link
             href="/products"
-            className={`flex flex-col items-center py-2 text-xs ${isActive("/products") ? "text-primary" : "text-gray-500"}`}
+            className={`flex flex-col items-center py-2 text-xs w-full ${isActive("/products") ? "text-primary" : "text-gray-500"}`}
           >
             <ShoppingBag className="h-5 w-5" />
             Shop
           </Link>
         </li>
         {user?.role === "seller" && (
-          <li>
+          <li className="flex-1">
             <Link
               href="/seller/dashboard"
-              className={`flex flex-col items-center py-2 text-xs ${isActive("/seller/dashboard") ? "text-primary" : "text-gray-500"}`}
+              className={`flex flex-col items-center py-2 text-xs w-full ${isActive("/seller/dashboard") ? "text-primary" : "text-gray-500"}`}
             >
               <LayoutDashboard className="h-5 w-5" />
               Dashboard
@@ -42,10 +42,10 @@ export default function MobileNav() {
           </li>
         )}
         {user?.role === "buyer" && (
-          <li>
+          <li className="flex-1">
             <Link
               href="/buyer/orders"
-              className={`flex flex-col items-center py-2 text-xs ${isActive("/buyer/orders") ? "text-primary" : "text-gray-500"}`}
+              className={`flex flex-col items-center py-2 text-xs w-full ${isActive("/buyer/orders") ? "text-primary" : "text-gray-500"}`}
             >
               <ListOrdered className="h-5 w-5" />
               Orders
@@ -53,10 +53,10 @@ export default function MobileNav() {
           </li>
         )}
         {(user?.role === "buyer" || user?.role === "seller") && (
-          <li>
+          <li className="flex-1">
             <Link
               href="/buyer/offers"
-              className={`flex flex-col items-center py-2 text-xs ${isActive("/buyer/offers") ? "text-primary" : "text-gray-500"}`}
+              className={`flex flex-col items-center py-2 text-xs w-full ${isActive("/buyer/offers") ? "text-primary" : "text-gray-500"}`}
             >
               <DollarSign className="h-5 w-5" />
               Offers
@@ -64,10 +64,10 @@ export default function MobileNav() {
           </li>
         )}
         {user?.role === "seller" && (
-          <li>
+          <li className="flex-1">
             <Link
               href="/seller/orders"
-              className={`flex flex-col items-center py-2 text-xs ${isActive("/seller/orders") ? "text-primary" : "text-gray-500"}`}
+              className={`flex flex-col items-center py-2 text-xs w-full ${isActive("/seller/orders") ? "text-primary" : "text-gray-500"}`}
             >
               <ListOrdered className="h-5 w-5" />
               Orders
@@ -75,10 +75,10 @@ export default function MobileNav() {
           </li>
         )}
         {user?.role === "seller" && (
-          <li>
+          <li className="flex-1">
             <Link
               href="/seller/offers"
-              className={`flex flex-col items-center py-2 text-xs ${isActive("/seller/offers") ? "text-primary" : "text-gray-500"}`}
+              className={`flex flex-col items-center py-2 text-xs w-full ${isActive("/seller/offers") ? "text-primary" : "text-gray-500"}`}
             >
               <DollarSign className="h-5 w-5" />
               Offers
@@ -86,18 +86,19 @@ export default function MobileNav() {
           </li>
         )}
         {user && (
-          <li>
+          <li className="flex-1">
             <Link
               href={user.role === "buyer" ? "/buyer/messages" : "/seller/messages"}
-              className={`flex flex-col items-center py-2 text-xs ${isActive(user.role === "buyer" ? "/buyer/messages" : "/seller/messages") ? "text-primary" : "text-gray-500"}`}
+              className={`flex flex-col items-center py-2 text-xs w-full ${isActive(user.role === "buyer" ? "/buyer/messages" : "/seller/messages") ? "text-primary" : "text-gray-500"}`}
             >
               <MessageCircle className="h-5 w-5" />
               Messages
             </Link>
           </li>
         )}
-        <li className="relative">
+        <li className="relative flex-1">
           <button
+            type="button"
             onClick={() => setIsCartOpen(true)}
             className="flex flex-col items-center py-2 text-xs text-gray-500 w-full"
           >

--- a/client/src/pages/product-detail-page.tsx
+++ b/client/src/pages/product-detail-page.tsx
@@ -338,6 +338,9 @@ export default function ProductDetailPage() {
                   currentPrice={unitPrice}
                   currentStock={availableStock}
                   selectedVariations={selectedVariations}
+                  label="Request Quote"
+                  variant="default"
+                  className="w-full mb-2 bg-blue-600 hover:bg-blue-700"
                 />
                 <AskQuestionDialog onSubmit={q => questionMutation.mutate(q)} />
               </>


### PR DESCRIPTION
## Summary
- ensure mobile menu button doesn't submit forms by setting button type
- make bottom navigation buttons full-width and interactive
- style product page Request Quote button with blue primary color

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check` *(fails: missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68bd7dbd5f4483308568ff2ece924bd1